### PR TITLE
クローンのURＬがおかしかったので修正

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -10,7 +10,7 @@
 ## 1. リポジトリのクローン
 
 ```bash
-git clone https://github.com/yourusername/SigotoDekiruKun.git
+git git@github.com:KTC-Security-Circle/SigotoDekiruKun.git
 cd SigotoDekiruKun
 ```
 


### PR DESCRIPTION
# 概要

環境構築ガイドの修正

## 変更点

- 変更点1
リポジトリのクローンのところのURLがおかしかったため修正

## 関連Issue
