### PR TITLE
Fix/121-refactor-factory-class

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,6 +31,6 @@
     "DISPLAY": "dummy",
     "UV_PROJECT_ENVIRONMENT": "/home/vscode/.venv"
   },
-  "postCreateCommand": "chmod +x /workspace/.devcontainer/setup.sh && /workspace/.devcontainer/setup.sh",
+  "postCreateCommand": "bash /workspace/.devcontainer/setup.sh",
   "remoteUser": "vscode"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,7 @@ ignore = [
     "BLE001",
     "PLC0415",
     "FIX002",
+    "EXE002",
 ]
 unfixable = [
     "F401", # unused import

--- a/src/cli/commands/agent.py
+++ b/src/cli/commands/agent.py
@@ -255,6 +255,7 @@ def save_one_liner_as_task(
         ctx = _build_context_auto()
     gen_res = _generate_one_liner(ctx, provider=provider, model=model)
     text = gen_res.result
+    from logic.application.task_application_service import TaskApplicationService
     from logic.commands.task_commands import CreateTaskCommand
     from logic.container import service_container
     from models import TaskStatus
@@ -263,7 +264,7 @@ def save_one_liner_as_task(
         task_status = TaskStatus(status)
     except ValueError:  # [AI GENERATED]
         task_status = TaskStatus.INBOX  # [AI GENERATED]
-    service = service_container.get_task_application_service()
+    service = service_container.get_service(TaskApplicationService)
     truncated = text[:60]
     cmd = CreateTaskCommand(title=truncated, description=text, status=task_status)
     created = service.create_task(cmd)

--- a/src/cli/commands/memo.py
+++ b/src/cli/commands/memo.py
@@ -33,9 +33,10 @@ console = Console()
 
 
 def _get_service() -> MemoApplicationService:  # type: ignore[name-defined]
+    from logic.application.memo_application_service import MemoApplicationService
     from logic.container import service_container
 
-    return service_container.get_memo_application_service()
+    return service_container.get_service(MemoApplicationService)
 
 
 # ==== Helpers ====

--- a/src/cli/commands/project.py
+++ b/src/cli/commands/project.py
@@ -28,9 +28,10 @@ console = Console()
 
 
 def _get_service() -> ProjectApplicationService:
+    from logic.application.project_application_service import ProjectApplicationService
     from logic.container import service_container
 
-    return service_container.get_project_application_service()
+    return service_container.get_service(ProjectApplicationService)
 
 
 @elapsed_time()

--- a/src/cli/commands/tag.py
+++ b/src/cli/commands/tag.py
@@ -27,9 +27,10 @@ console = Console()
 
 
 def _get_service() -> TagApplicationService:
+    from logic.application.tag_application_service import TagApplicationService
     from logic.container import service_container
 
-    return service_container.get_tag_application_service()
+    return service_container.get_service(TagApplicationService)
 
 
 @elapsed_time()

--- a/src/cli/commands/task.py
+++ b/src/cli/commands/task.py
@@ -28,9 +28,10 @@ console = Console()
 
 
 def _get_service() -> TaskApplicationService:
+    from logic.application.task_application_service import TaskApplicationService
     from logic.container import service_container
 
-    return service_container.get_task_application_service()
+    return service_container.get_service(TaskApplicationService)
 
 
 @elapsed_time()

--- a/src/cli/commands/task_qa.py
+++ b/src/cli/commands/task_qa.py
@@ -32,9 +32,10 @@ def _get_service() -> TaskApplicationService:
     Returns:
         TaskApplicationService: タスクアプリケーションサービス
     """
+    from logic.application.task_application_service import TaskApplicationService
     from logic.container import service_container
 
-    return service_container.get_task_application_service()
+    return service_container.get_service(TaskApplicationService)
 
 
 # === Helpers ===

--- a/src/cli/commands/task_status.py
+++ b/src/cli/commands/task_status.py
@@ -31,9 +31,10 @@ console = Console()
 
 def _get_service() -> TaskApplicationService:  # [AI GENERATED]
     """TaskApplicationService を取得 [AI GENERATED]"""
+    from logic.application.task_application_service import TaskApplicationService
     from logic.container import service_container
 
-    return service_container.get_task_application_service()
+    return service_container.get_service(TaskApplicationService)
 
 
 @elapsed_time()

--- a/src/cli/commands/task_tag.py
+++ b/src/cli/commands/task_tag.py
@@ -37,9 +37,10 @@ console = Console()
 
 
 def _get_service() -> TaskTagApplicationService:  # type: ignore[name-defined]
+    from logic.application.task_tag_application_service import TaskTagApplicationService
     from logic.container import service_container
 
-    return service_container.get_task_tag_application_service()
+    return service_container.get_service(TaskTagApplicationService)
 
 
 # ==== Helpers ====

--- a/src/logic/application/memo_application_service.py
+++ b/src/logic/application/memo_application_service.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from logic.application.base import BaseApplicationService
+from logic.services.memo_service import MemoService
 from logic.unit_of_work import SqlModelUnitOfWork
 
 if TYPE_CHECKING:
@@ -60,7 +61,7 @@ class MemoApplicationService(BaseApplicationService):
 
         # [AI GENERATED] Unit of Workでトランザクション管理
         with self._unit_of_work_factory() as uow:
-            memo_service = uow.service_factory.create_memo_service()
+            memo_service = uow.service_factory.get_service(MemoService)
             created_memo = memo_service.create_memo(command.to_memo_create())
             uow.commit()
 
@@ -89,7 +90,7 @@ class MemoApplicationService(BaseApplicationService):
 
         # [AI GENERATED] Unit of Workでトランザクション管理
         with self._unit_of_work_factory() as uow:
-            memo_service = uow.service_factory.create_memo_service()
+            memo_service = uow.service_factory.get_service(MemoService)
             updated_memo = memo_service.update_memo(command.memo_id, command.to_memo_update())
             uow.commit()
 
@@ -112,7 +113,7 @@ class MemoApplicationService(BaseApplicationService):
 
         # [AI GENERATED] Unit of Workでトランザクション管理
         with self._unit_of_work_factory() as uow:
-            memo_service = uow.service_factory.create_memo_service()
+            memo_service = uow.service_factory.get_service(MemoService)
             success = memo_service.delete_memo(command.memo_id)
             uow.commit()
 
@@ -131,7 +132,7 @@ class MemoApplicationService(BaseApplicationService):
         logger.debug(f"メモ取得: ID {query.memo_id}")
 
         with self._unit_of_work_factory() as uow:
-            memo_service = uow.service_factory.create_memo_service()
+            memo_service = uow.service_factory.get_service(MemoService)
             return memo_service.get_memo_by_id(query.memo_id)
 
     def get_all_memos(self, query: GetAllMemosQuery) -> list[MemoRead]:  # noqa: ARG002
@@ -146,7 +147,7 @@ class MemoApplicationService(BaseApplicationService):
         logger.debug("全メモ取得")
 
         with self._unit_of_work_factory() as uow:
-            memo_service = uow.service_factory.create_memo_service()
+            memo_service = uow.service_factory.get_service(MemoService)
             return memo_service.get_all_memos()
 
     def get_memos_by_task_id(self, query: GetMemosByTaskIdQuery) -> list[MemoRead]:
@@ -161,7 +162,7 @@ class MemoApplicationService(BaseApplicationService):
         logger.debug(f"タスクメモ取得: タスクID {query.task_id}")
 
         with self._unit_of_work_factory() as uow:
-            memo_service = uow.service_factory.create_memo_service()
+            memo_service = uow.service_factory.get_service(MemoService)
             return memo_service.get_memos_by_task_id(query.task_id)
 
     def search_memos(self, query: SearchMemosQuery) -> list[MemoRead]:
@@ -180,5 +181,5 @@ class MemoApplicationService(BaseApplicationService):
             return []
 
         with self._unit_of_work_factory() as uow:
-            memo_service = uow.service_factory.create_memo_service()
+            memo_service = uow.service_factory.get_service(MemoService)
             return memo_service.search_memos(query.query)

--- a/src/logic/application/project_application_service.py
+++ b/src/logic/application/project_application_service.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from logic.application.base import BaseApplicationService
+from logic.services.project_service import ProjectService
 from logic.unit_of_work import SqlModelUnitOfWork
 
 if TYPE_CHECKING:
@@ -62,7 +63,7 @@ class ProjectApplicationService(BaseApplicationService):
             raise ValueError(msg)
 
         with self._unit_of_work_factory() as uow:
-            project_service = uow.service_factory.create_project_service()
+            project_service = uow.service_factory.get_service(ProjectService)
             created_project = project_service.create_project(command.to_project_create())
             uow.commit()
 
@@ -84,7 +85,7 @@ class ProjectApplicationService(BaseApplicationService):
         logger.debug(f"プロジェクト取得: {query.project_id}")
 
         with self._unit_of_work_factory() as uow:
-            project_service = uow.service_factory.create_project_service()
+            project_service = uow.service_factory.get_service(ProjectService)
             project = project_service.get_project_by_id(query.project_id)
 
             if project is None:
@@ -106,7 +107,7 @@ class ProjectApplicationService(BaseApplicationService):
         logger.debug("全プロジェクト取得")
 
         with self._unit_of_work_factory() as uow:
-            project_service = uow.service_factory.create_project_service()
+            project_service = uow.service_factory.get_service(ProjectService)
             return project_service.get_all_projects()
 
     def search_projects_by_title(self, query: SearchProjectsByTitleQuery) -> list[ProjectRead]:
@@ -121,7 +122,7 @@ class ProjectApplicationService(BaseApplicationService):
         logger.debug(f"プロジェクト検索: {query.title_query}")
 
         with self._unit_of_work_factory() as uow:
-            project_service = uow.service_factory.create_project_service()
+            project_service = uow.service_factory.get_service(ProjectService)
             return project_service.search_projects(query.title_query)
 
     def update_project(self, command: UpdateProjectCommand) -> ProjectRead:
@@ -145,7 +146,7 @@ class ProjectApplicationService(BaseApplicationService):
             raise ValueError(msg)
 
         with self._unit_of_work_factory() as uow:
-            project_service = uow.service_factory.create_project_service()
+            project_service = uow.service_factory.get_service(ProjectService)
             updated_project = project_service.update_project(command.project_id, command.to_project_update())
             uow.commit()
 
@@ -165,7 +166,7 @@ class ProjectApplicationService(BaseApplicationService):
         logger.info(f"プロジェクト削除開始: {command.project_id}")
 
         with self._unit_of_work_factory() as uow:
-            project_service = uow.service_factory.create_project_service()
+            project_service = uow.service_factory.get_service(ProjectService)
             success = project_service.delete_project(command.project_id)
 
             if not success:

--- a/src/logic/application/tag_application_service.py
+++ b/src/logic/application/tag_application_service.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from logic.application.base import BaseApplicationService
+from logic.services.tag_service import TagService
 from logic.unit_of_work import SqlModelUnitOfWork
 
 if TYPE_CHECKING:
@@ -54,7 +55,7 @@ class TagApplicationService(BaseApplicationService):
             raise ValueError(msg)
 
         with self._unit_of_work_factory() as uow:
-            tag_service = uow.service_factory.create_tag_service()
+            tag_service = uow.service_factory.get_service(TagService)
             created_tag = tag_service.create_tag(command.to_tag_create())
             uow.commit()
 
@@ -76,7 +77,7 @@ class TagApplicationService(BaseApplicationService):
         logger.debug(f"タグ取得: {query.tag_id}")
 
         with self._unit_of_work_factory() as uow:
-            tag_service = uow.service_factory.create_tag_service()
+            tag_service = uow.service_factory.get_service(TagService)
             tag = tag_service.get_tag_by_id(query.tag_id)
 
             if tag is None:
@@ -98,7 +99,7 @@ class TagApplicationService(BaseApplicationService):
         logger.debug("全タグ取得")
 
         with self._unit_of_work_factory() as uow:
-            tag_service = uow.service_factory.create_tag_service()
+            tag_service = uow.service_factory.get_service(TagService)
             return tag_service.get_all_tags()
 
     def search_tags_by_name(self, query: SearchTagsByNameQuery) -> list[TagRead]:
@@ -113,7 +114,7 @@ class TagApplicationService(BaseApplicationService):
         logger.debug(f"タグ名検索: {query.name_query}")
 
         with self._unit_of_work_factory() as uow:
-            tag_service = uow.service_factory.create_tag_service()
+            tag_service = uow.service_factory.get_service(TagService)
             return tag_service.search_tags(query.name_query)
 
     def update_tag(self, command: UpdateTagCommand) -> TagRead:
@@ -137,7 +138,7 @@ class TagApplicationService(BaseApplicationService):
             raise ValueError(msg)
 
         with self._unit_of_work_factory() as uow:
-            tag_service = uow.service_factory.create_tag_service()
+            tag_service = uow.service_factory.get_service(TagService)
             updated_tag = tag_service.update_tag(command.tag_id, command.to_tag_update())
             uow.commit()
 
@@ -157,7 +158,7 @@ class TagApplicationService(BaseApplicationService):
         logger.info(f"タグ削除開始: {command.tag_id}")
 
         with self._unit_of_work_factory() as uow:
-            tag_service = uow.service_factory.create_tag_service()
+            tag_service = uow.service_factory.get_service(TagService)
             success = tag_service.delete_tag(command.tag_id)
 
             if not success:

--- a/src/logic/application/task_application_service.py
+++ b/src/logic/application/task_application_service.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from logic.application.base import BaseApplicationService
 from logic.services.quick_action_mapping_service import QuickActionMappingService
+from logic.services.task_service import TaskService
 from logic.services.task_status_display_service import (
     TaskStatusDisplay,
     TaskStatusDisplayService,
@@ -72,7 +73,7 @@ class TaskApplicationService(BaseApplicationService):
 
         # Unit of Workでトランザクション管理
         with self._unit_of_work_factory() as uow:
-            task_service = uow.service_factory.create_task_service()
+            task_service = uow.service_factory.get_service(TaskService)
             created_task = task_service.create_task(command.to_task_create())
             uow.commit()
 
@@ -100,7 +101,7 @@ class TaskApplicationService(BaseApplicationService):
             raise ValueError(msg)
 
         with self._unit_of_work_factory() as uow:
-            task_service = uow.service_factory.create_task_service()
+            task_service = uow.service_factory.get_service(TaskService)
             updated_task = task_service.update_task(command.task_id, command.to_task_update())
             uow.commit()
 
@@ -119,7 +120,7 @@ class TaskApplicationService(BaseApplicationService):
         logger.info(f"タスク削除開始: {command.task_id}")
 
         with self._unit_of_work_factory() as uow:
-            task_service = uow.service_factory.create_task_service()
+            task_service = uow.service_factory.get_service(TaskService)
             task_service.delete_task(command.task_id)
             uow.commit()
 
@@ -140,7 +141,7 @@ class TaskApplicationService(BaseApplicationService):
         logger.info(f"タスクステータス更新開始: {command.task_id} -> {command.new_status.value}")
 
         with self._unit_of_work_factory() as uow:
-            task_service = uow.service_factory.create_task_service()
+            task_service = uow.service_factory.get_service(TaskService)
 
             # 現在のタスクを取得
             task = task_service.get_task_by_id(command.task_id)
@@ -175,7 +176,7 @@ class TaskApplicationService(BaseApplicationService):
             タスクリスト
         """
         with self._unit_of_work_factory() as uow:
-            task_service = uow.service_factory.create_task_service()
+            task_service = uow.service_factory.get_service(TaskService)
             return task_service.get_tasks_by_status(query.status)
 
     def get_today_tasks_count(self, query: GetTodayTasksCountQuery) -> int:
@@ -189,7 +190,7 @@ class TaskApplicationService(BaseApplicationService):
         """
         _ = query  # 将来の拡張用パラメータ
         with self._unit_of_work_factory() as uow:
-            task_service = uow.service_factory.create_task_service()
+            task_service = uow.service_factory.get_service(TaskService)
             return task_service.get_today_tasks_count()
 
     # [AI GENERATED] 追加: 完了タスク件数取得
@@ -200,7 +201,7 @@ class TaskApplicationService(BaseApplicationService):
             int: 完了タスク件数
         """
         with self._unit_of_work_factory() as uow:
-            task_service = uow.service_factory.create_task_service()
+            task_service = uow.service_factory.get_service(TaskService)
             return task_service.get_completed_tasks_count()
 
     # [AI GENERATED] 追加: 期限超過タスク件数取得
@@ -211,7 +212,7 @@ class TaskApplicationService(BaseApplicationService):
             int: 期限超過タスク件数
         """
         with self._unit_of_work_factory() as uow:
-            task_service = uow.service_factory.create_task_service()
+            task_service = uow.service_factory.get_service(TaskService)
             return task_service.get_overdue_tasks_count()
 
     def get_task_by_id(self, query: GetTaskByIdQuery) -> TaskRead | None:
@@ -224,7 +225,7 @@ class TaskApplicationService(BaseApplicationService):
             タスク（見つからない場合はNone）
         """
         with self._unit_of_work_factory() as uow:
-            task_service = uow.service_factory.create_task_service()
+            task_service = uow.service_factory.get_service(TaskService)
             return task_service.get_task_by_id(query.task_id)
 
     def get_all_tasks_by_status_dict(self, query: GetAllTasksByStatusDictQuery) -> dict[TaskStatus, list[TaskRead]]:
@@ -242,7 +243,7 @@ class TaskApplicationService(BaseApplicationService):
         result = {}
 
         with self._unit_of_work_factory() as uow:
-            task_service = uow.service_factory.create_task_service()
+            task_service = uow.service_factory.get_service(TaskService)
 
             for status in TaskStatus:
                 result[status] = task_service.get_tasks_by_status(status)

--- a/src/logic/application/task_tag_application_service.py
+++ b/src/logic/application/task_tag_application_service.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from logic.application.base import BaseApplicationService
+from logic.services.task_tag_service import TaskTagService
 from logic.unit_of_work import SqlModelUnitOfWork
 
 if TYPE_CHECKING:
@@ -69,7 +70,7 @@ class TaskTagApplicationService(BaseApplicationService):
 
         # Unit of Workでトランザクション管理
         with self._unit_of_work_factory() as uow:
-            task_tag_service = uow.service_factory.create_task_tag_service()
+            task_tag_service = uow.service_factory.get_service(TaskTagService)
             created_task_tag = task_tag_service.create_task_tag(command.to_task_tag_create())
             uow.commit()
 
@@ -89,7 +90,7 @@ class TaskTagApplicationService(BaseApplicationService):
         logger.debug("全タスクタグ取得")
 
         with self._unit_of_work_factory() as uow:
-            task_tag_service = uow.service_factory.create_task_tag_service()
+            task_tag_service = uow.service_factory.get_service(TaskTagService)
             return task_tag_service.get_all_task_tags()
 
     def delete_task_tag(self, command: DeleteTaskTagCommand) -> None:
@@ -113,7 +114,7 @@ class TaskTagApplicationService(BaseApplicationService):
             raise ValueError(msg)
 
         with self._unit_of_work_factory() as uow:
-            task_tag_service = uow.service_factory.create_task_tag_service()
+            task_tag_service = uow.service_factory.get_service(TaskTagService)
             task_tag_service.delete_task_tag(command.task_id, command.tag_id)
             uow.commit()
 
@@ -131,7 +132,7 @@ class TaskTagApplicationService(BaseApplicationService):
         logger.debug(f"タスクID別タスクタグ取得: {query.task_id}")
 
         with self._unit_of_work_factory() as uow:
-            task_tag_service = uow.service_factory.create_task_tag_service()
+            task_tag_service = uow.service_factory.get_service(TaskTagService)
             return task_tag_service.get_task_tags_by_task_id(query.task_id)
 
     def get_task_tags_by_tag_id(self, query: GetTaskTagsByTagIdQuery) -> list[TaskTagRead]:
@@ -146,7 +147,7 @@ class TaskTagApplicationService(BaseApplicationService):
         logger.debug(f"タグID別タスクタグ取得: {query.tag_id}")
 
         with self._unit_of_work_factory() as uow:
-            task_tag_service = uow.service_factory.create_task_tag_service()
+            task_tag_service = uow.service_factory.get_service(TaskTagService)
             return task_tag_service.get_task_tags_by_tag_id(query.tag_id)
 
     def get_task_tag_by_task_and_tag(self, query: GetTaskTagByTaskAndTagQuery) -> TaskTagRead | None:
@@ -161,7 +162,7 @@ class TaskTagApplicationService(BaseApplicationService):
         logger.debug(f"タスクタグ取得: Task {query.task_id}, Tag {query.tag_id}")
 
         with self._unit_of_work_factory() as uow:
-            task_tag_service = uow.service_factory.create_task_tag_service()
+            task_tag_service = uow.service_factory.get_service(TaskTagService)
             return task_tag_service.get_task_tag_by_task_and_tag(query.task_id, query.tag_id)
 
     def check_task_tag_exists(self, query: CheckTaskTagExistsQuery) -> bool:
@@ -176,7 +177,7 @@ class TaskTagApplicationService(BaseApplicationService):
         logger.debug(f"タスクタグ存在確認: Task {query.task_id}, Tag {query.tag_id}")
 
         with self._unit_of_work_factory() as uow:
-            task_tag_service = uow.service_factory.create_task_tag_service()
+            task_tag_service = uow.service_factory.get_service(TaskTagService)
             return task_tag_service.check_task_tag_exists(query.task_id, query.tag_id)
 
     def delete_task_tags_by_task_id(self, command: DeleteTaskTagsByTaskCommand) -> None:
@@ -197,7 +198,7 @@ class TaskTagApplicationService(BaseApplicationService):
             raise ValueError(msg)
 
         with self._unit_of_work_factory() as uow:
-            task_tag_service = uow.service_factory.create_task_tag_service()
+            task_tag_service = uow.service_factory.get_service(TaskTagService)
             task_tag_service.delete_task_tags_by_task_id(command.task_id)
             uow.commit()
 
@@ -221,7 +222,7 @@ class TaskTagApplicationService(BaseApplicationService):
             raise ValueError(msg)
 
         with self._unit_of_work_factory() as uow:
-            task_tag_service = uow.service_factory.create_task_tag_service()
+            task_tag_service = uow.service_factory.get_service(TaskTagService)
             task_tag_service.delete_task_tags_by_tag_id(command.tag_id)
             uow.commit()
 

--- a/src/logic/container.py
+++ b/src/logic/container.py
@@ -5,97 +5,102 @@ Application Service層の依存性を管理するコンテナ
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar, cast
 
 if TYPE_CHECKING:
-    from logic.application.memo_application_service import MemoApplicationService
-    from logic.application.project_application_service import ProjectApplicationService
-    from logic.application.tag_application_service import TagApplicationService
-    from logic.application.task_application_service import TaskApplicationService
-    from logic.application.task_tag_application_service import TaskTagApplicationService
+    from collections.abc import Callable
+
+_ApplicationServiceT = TypeVar("_ApplicationServiceT")
+
+
+class ServiceContainerError(Exception):
+    """ServiceContainer に関連する例外"""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
 
 
 class ServiceContainer:
     """サービスコンテナ（Dependency Injection）
 
-    Application Serviceの依存性を管理し、シングルトンパターンで提供します。
+    Application Serviceの依存性を管理し、必要に応じて遅延初期化したシングルトンとして提供します。
     """
 
     def __init__(self) -> None:
         """ServiceContainerの初期化"""
-        self._memo_app_service: MemoApplicationService | None = None
-        self._task_app_service: TaskApplicationService | None = None
-        self._project_app_service: ProjectApplicationService | None = None
-        self._tag_app_service: TagApplicationService | None = None
-        self._task_tag_app_service: TaskTagApplicationService | None = None
+        self._service_builders: dict[type[object], Callable[[ServiceContainer], object]] = {}
+        self._service_instances: dict[type[object], object] = {}
+        self._defaults_registered = False
 
-    def get_memo_application_service(self) -> MemoApplicationService:
-        """メモApplication Serviceを取得
+    def register_service(
+        self,
+        service_type: type[_ApplicationServiceT],
+        builder: Callable[[ServiceContainer], _ApplicationServiceT],
+    ) -> None:
+        """Application Service を登録する
+
+        Args:
+            service_type: 登録対象のApplication Serviceクラス
+            builder: Application Serviceインスタンスを生成するビルダー
+        """
+        self._service_builders[service_type] = cast("Callable[[ServiceContainer], object]", builder)
+
+    def get_service(self, service_type: type[_ApplicationServiceT]) -> _ApplicationServiceT:
+        """登録済みのApplication Serviceを取得する
+
+        遅延初期化を行い、初回アクセス時にビルダーを使用してインスタンスを生成します。
+
+        Args:
+            service_type: 取得対象のApplication Serviceクラス
 
         Returns:
-            MemoApplicationService: メモApplication Serviceインスタンス
+            Application Serviceインスタンス
+
+        Raises:
+            ServiceContainerError: 未登録のサービスが要求された場合、または生成に失敗した場合
         """
-        if self._memo_app_service is None:
-            from logic.application.memo_application_service import MemoApplicationService
+        instance = self._service_instances.get(service_type)
+        if instance is not None:
+            return cast("_ApplicationServiceT", instance)
 
-            self._memo_app_service = MemoApplicationService()
-        return self._memo_app_service
+        builder = self._service_builders.get(service_type)
+        if builder is None and not self._defaults_registered:
+            self.register_default_services()
+            builder = self._service_builders.get(service_type)
+        if builder is None:
+            message = f"ServiceContainerに登録されていないサービスが要求されました: {service_type.__name__}"
+            raise ServiceContainerError(message)
 
-    def get_task_application_service(self) -> TaskApplicationService:
-        """タスクApplication Serviceを取得
+        try:
+            instance = builder(self)
+        except Exception as exc:
+            message = f"ServiceContainerでサービスの初期化に失敗しました: {service_type.__name__}"
+            raise ServiceContainerError(message) from exc
 
-        Returns:
-            TaskApplicationService: タスクApplication Serviceインスタンス
-        """
-        if self._task_app_service is None:
-            from logic.application.task_application_service import TaskApplicationService
-
-            self._task_app_service = TaskApplicationService()
-        return self._task_app_service
-
-    def get_project_application_service(self) -> ProjectApplicationService:
-        """プロジェクトApplication Serviceを取得
-
-        Returns:
-            ProjectApplicationService: プロジェクトApplication Serviceインスタンス
-        """
-        if self._project_app_service is None:
-            from logic.application.project_application_service import ProjectApplicationService
-
-            self._project_app_service = ProjectApplicationService()
-        return self._project_app_service
-
-    def get_tag_application_service(self) -> TagApplicationService:
-        """タグApplication Serviceを取得
-
-        Returns:
-            TagApplicationService: タグApplication Serviceインスタンス
-        """
-        if self._tag_app_service is None:
-            from logic.application.tag_application_service import TagApplicationService
-
-            self._tag_app_service = TagApplicationService()
-        return self._tag_app_service
-
-    def get_task_tag_application_service(self) -> TaskTagApplicationService:
-        """タスクタグApplication Serviceを取得
-
-        Returns:
-            TaskTagApplicationService: タスクタグApplication Serviceインスタンス
-        """
-        if self._task_tag_app_service is None:
-            from logic.application.task_tag_application_service import TaskTagApplicationService
-
-            self._task_tag_app_service = TaskTagApplicationService()
-        return self._task_tag_app_service
+        self._service_instances[service_type] = instance
+        return cast("_ApplicationServiceT", instance)
 
     def reset(self) -> None:
         """コンテナをリセット（主にテスト用）"""
-        self._memo_app_service = None
-        self._task_app_service = None
-        self._project_app_service = None
-        self._tag_app_service = None
-        self._task_tag_app_service = None
+        self._service_instances.clear()
+
+    def register_default_services(self) -> None:
+        """アプリケーションで使用するデフォルトのサービスを登録する"""
+        if self._defaults_registered:
+            return
+
+        from logic.application.memo_application_service import MemoApplicationService
+        from logic.application.project_application_service import ProjectApplicationService
+        from logic.application.tag_application_service import TagApplicationService
+        from logic.application.task_application_service import TaskApplicationService
+        from logic.application.task_tag_application_service import TaskTagApplicationService
+
+        self.register_service(MemoApplicationService, lambda _: MemoApplicationService())
+        self.register_service(TaskApplicationService, lambda _: TaskApplicationService())
+        self.register_service(ProjectApplicationService, lambda _: ProjectApplicationService())
+        self.register_service(TagApplicationService, lambda _: TagApplicationService())
+        self.register_service(TaskTagApplicationService, lambda _: TaskTagApplicationService())
+        self._defaults_registered = True
 
 
 # グローバルなサービスコンテナのインスタンス

--- a/src/logic/factory.py
+++ b/src/logic/factory.py
@@ -82,7 +82,7 @@ class RepositoryFactory:
             RepositoryFactoryError: リポジトリクラスが不正、または初期化に失敗した場合
         """
         try:
-            repository = repository_type(self.session)  # pyright: ignore[reportCallIssue]
+            repository = repository_type(self.session)
         except TypeError as exc:
             error_message = (
                 "RepositoryFactoryでリポジトリの初期化に失敗しました。"

--- a/src/logic/factory.py
+++ b/src/logic/factory.py
@@ -271,7 +271,8 @@ def get_application_service_container() -> ServiceContainer:
 
     Example:
         >>> container = get_application_service_container()
-        >>> task_app_service = container.get_task_application_service()
+        >>> from logic.application.task_application_service import TaskApplicationService
+        >>> task_app_service = container.get_service(TaskApplicationService)
         >>> command = CreateTaskCommand(title="新しいタスク")
         >>> task = task_app_service.create_task(command)
     """

--- a/src/logic/factory.py
+++ b/src/logic/factory.py
@@ -7,7 +7,11 @@ Application Service層への移行をサポートするため、
 従来のcreate_service_factory関数は引き続き利用可能です。
 """
 
+from collections.abc import Callable
+from typing import TypeVar, cast
+
 from sqlmodel import Session
+from typing_extensions import deprecated
 
 from logic.container import ServiceContainer
 from logic.repositories.memo import MemoRepository
@@ -21,6 +25,20 @@ from logic.services.project_service import ProjectService
 from logic.services.tag_service import TagService
 from logic.services.task_service import TaskService
 from logic.services.task_tag_service import TaskTagService
+
+_ServiceT = TypeVar("_ServiceT")
+
+
+class ServiceFactoryError(Exception):
+    """サービスファクトリ関連の例外"""
+
+    def __init__(self, message: str) -> None:
+        """ServiceFactoryError を初期化する
+
+        Args:
+            message (str): エラーメッセージ
+        """
+        super().__init__(message)
 
 
 class RepositoryFactory:
@@ -92,86 +110,140 @@ class ServiceFactory:
         """
         self.repository_factory = repository_factory
 
+        self._service_builders: dict[type[object], Callable[[RepositoryFactory], object]] = {}
+        self._register_default_services()
+
+    def register_service(
+        self,
+        service_type: type[_ServiceT],
+        builder: Callable[[RepositoryFactory], _ServiceT],
+    ) -> None:
+        """サービスのビルダーを登録する
+
+        Args:
+            service_type (type[_ServiceT]): 登録対象のサービスクラス
+            builder (Callable[[RepositoryFactory], _ServiceT]): サービスインスタンスを生成するビルダー
+        """
+        self._service_builders[service_type] = cast(
+            "Callable[[RepositoryFactory], object]",
+            builder,
+        )
+
+    def get_service(self, service_type: type[_ServiceT]) -> _ServiceT:
+        """サービスインスタンスを取得する
+
+        Args:
+            service_type (type[_ServiceT]): 取得対象のサービスクラス
+
+        Returns:
+            _ServiceT: サービスインスタンス
+
+        Raises:
+            ServiceFactoryError: サービスが登録されていない場合
+        """
+        builder = self._service_builders.get(service_type)
+        if builder is None:
+            error_message = f"ServiceFactoryに登録されていないサービスが要求されました: {service_type.__name__}"
+            raise ServiceFactoryError(error_message)
+
+        return cast("_ServiceT", builder(self.repository_factory))
+
+    def _register_default_services(self) -> None:
+        """既定のサービスビルダーを登録する"""
+        self.register_service(
+            MemoService,
+            lambda repo_factory: MemoService(
+                memo_repo=repo_factory.create_memo_repository(),
+                task_repo=repo_factory.create_task_repository(),
+            ),
+        )
+        self.register_service(
+            TaskService,
+            lambda repo_factory: TaskService(
+                task_repo=repo_factory.create_task_repository(),
+                project_repo=repo_factory.create_project_repository(),
+                tag_repo=repo_factory.create_tag_repository(),
+                task_tag_repo=repo_factory.create_task_tag_repository(),
+            ),
+        )
+        self.register_service(
+            ProjectService,
+            lambda repo_factory: ProjectService(
+                project_repo=repo_factory.create_project_repository(),
+                task_repo=repo_factory.create_task_repository(),
+            ),
+        )
+        self.register_service(
+            TagService,
+            lambda repo_factory: TagService(
+                tag_repo=repo_factory.create_tag_repository(),
+                task_tag_repo=repo_factory.create_task_tag_repository(),
+            ),
+        )
+        self.register_service(
+            TaskTagService,
+            lambda repo_factory: TaskTagService(
+                task_tag_repo=repo_factory.create_task_tag_repository(),
+            ),
+        )
+        self.register_service(
+            OneLinerService,
+            lambda _: OneLinerService(),
+        )
+
+    @deprecated("Use get_service(MemoService) instead")
     def create_memo_service(self) -> MemoService:
         """MemoServiceを作成する
 
         Returns:
             MemoService: メモサービスインスタンス
         """
-        memo_repo = self.repository_factory.create_memo_repository()
-        task_repo = self.repository_factory.create_task_repository()
+        return self.get_service(MemoService)
 
-        return MemoService(
-            memo_repo=memo_repo,
-            task_repo=task_repo,
-        )
-
+    @deprecated("Use get_service(TaskService) instead")
     def create_task_service(self) -> TaskService:
         """TaskServiceを作成する
 
         Returns:
             TaskService: タスクサービスインスタンス
         """
-        task_repo = self.repository_factory.create_task_repository()
-        project_repo = self.repository_factory.create_project_repository()
-        tag_repo = self.repository_factory.create_tag_repository()
-        task_tag_repo = self.repository_factory.create_task_tag_repository()
+        return self.get_service(TaskService)
 
-        return TaskService(
-            task_repo=task_repo,
-            project_repo=project_repo,
-            tag_repo=tag_repo,
-            task_tag_repo=task_tag_repo,
-        )
-
+    @deprecated("Use get_service(ProjectService) instead")
     def create_project_service(self) -> ProjectService:
         """ProjectServiceを作成する
 
         Returns:
             ProjectService: プロジェクトサービスインスタンス
         """
-        project_repo = self.repository_factory.create_project_repository()
-        task_repo = self.repository_factory.create_task_repository()
+        return self.get_service(ProjectService)
 
-        return ProjectService(
-            project_repo=project_repo,
-            task_repo=task_repo,
-        )
-
+    @deprecated("Use get_service(TagService) instead")
     def create_tag_service(self) -> TagService:
         """TagServiceを作成する
 
         Returns:
             TagService: タグサービスインスタンス
         """
-        tag_repo = self.repository_factory.create_tag_repository()
-        task_tag_repo = self.repository_factory.create_task_tag_repository()
+        return self.get_service(TagService)
 
-        return TagService(
-            tag_repo=tag_repo,
-            task_tag_repo=task_tag_repo,
-        )
-
+    @deprecated("Use get_service(TaskTagService) instead")
     def create_task_tag_service(self) -> TaskTagService:
         """TaskTagServiceを作成する
 
         Returns:
             TaskTagService: タスクタグサービスインスタンス
         """
-        task_tag_repo = self.repository_factory.create_task_tag_repository()
+        return self.get_service(TaskTagService)
 
-        return TaskTagService(
-            task_tag_repo=task_tag_repo,
-        )
-
+    @deprecated("Use get_service(OneLinerService) instead")
     def create_one_liner_service(self) -> OneLinerService:
         """OneLinerServiceを作成する
 
         Returns:
             OneLinerService: 一言コメントサービスインスタンス
         """
-        # [AI GENERATED] OneLinerServiceはリポジトリに依存しないため、直接インスタンス化
-        return OneLinerService()
+        return self.get_service(OneLinerService)
 
 
 def create_service_factory(session: Session) -> ServiceFactory:

--- a/src/logic/repositories/base.py
+++ b/src/logic/repositories/base.py
@@ -13,14 +13,15 @@ class BaseRepository[T: SQLModel, CreateT: SQLModel, UpdateT: SQLModel]:
     CRUD操作の基本実装を提供する。
     """
 
-    def __init__(self, model_class: type[T], session: Session) -> None:
+    model_class: type[T]
+
+    def __init__(self, session: Session) -> None:
         """リポジトリを初期化する
 
         Args:
             model_class: このリポジトリが扱うモデルクラス
             session: データベースセッション
         """
-        self.model_class = model_class
         self.session = session
 
     def create(self, entity_data: CreateT) -> T:

--- a/src/logic/repositories/memo.py
+++ b/src/logic/repositories/memo.py
@@ -22,7 +22,8 @@ class MemoRepository(BaseRepository[Memo, MemoCreate, MemoUpdate]):
         Args:
             session: データベースセッション
         """
-        super().__init__(Memo, session)
+        self.model_class = Memo
+        super().__init__(session)
 
     def get_by_task_id(self, task_id: uuid.UUID) -> list[Memo]:
         """指定されたタスクIDのメモ一覧を取得する

--- a/src/logic/repositories/project.py
+++ b/src/logic/repositories/project.py
@@ -20,7 +20,8 @@ class ProjectRepository(BaseRepository[Project, ProjectCreate, ProjectUpdate]):
         Args:
             session: データベースセッション
         """
-        super().__init__(Project, session)
+        self.model_class = Project
+        super().__init__(session)
 
     def get_all(self) -> list[Project]:
         """全てのプロジェクト一覧を取得する

--- a/src/logic/repositories/tag.py
+++ b/src/logic/repositories/tag.py
@@ -20,7 +20,8 @@ class TagRepository(BaseRepository[Tag, TagCreate, TagUpdate]):
         Args:
             session: データベースセッション
         """
-        super().__init__(Tag, session)
+        self.model_class = Tag
+        super().__init__(session)
 
     def get_all(self) -> list[Tag]:
         """全てのタグ一覧を取得する

--- a/src/logic/repositories/task.py
+++ b/src/logic/repositories/task.py
@@ -23,7 +23,8 @@ class TaskRepository(BaseRepository[Task, TaskCreate, TaskUpdate]):
         Args:
             session: データベースセッション
         """
-        super().__init__(Task, session)
+        self.model_class = Task
+        super().__init__(session)
 
     def get_by_project_id(self, project_id: uuid.UUID) -> list[Task]:
         """指定されたプロジェクトIDのタスク一覧を取得する

--- a/src/logic/repositories/task_tag.py
+++ b/src/logic/repositories/task_tag.py
@@ -25,7 +25,8 @@ class TaskTagRepository(BaseRepository[TaskTag, TaskTagCreate, TaskTagCreate]):
         Args:
             session: データベースセッション
         """
-        super().__init__(TaskTag, session)
+        self.model_class = TaskTag
+        super().__init__(session)
 
     def get_by_id(self, entity_id: uuid.UUID) -> TaskTag | None:  # noqa: ARG002
         """TaskTagは複合主キーのため、このメソッドは使用しない

--- a/src/views/home/view.py
+++ b/src/views/home/view.py
@@ -2,15 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import flet as ft
 
+from logic.application.task_application_service import TaskApplicationService
 from views.home.components import MainActionSection, create_welcome_message
 from views.shared import BaseView, ErrorHandlingMixin
-
-if TYPE_CHECKING:
-    from logic.application.task_application_service import TaskApplicationService
 
 
 class HomeView(BaseView, ErrorHandlingMixin):
@@ -28,7 +24,7 @@ class HomeView(BaseView, ErrorHandlingMixin):
         super().__init__(page)
 
         # 依存性注入
-        self.task_app_service: TaskApplicationService = self.container.get_task_application_service()
+        self.task_app_service: TaskApplicationService = self.container.get_service(TaskApplicationService)
 
     def build_content(self) -> ft.Control:
         """ホーム画面のコンテンツを構築

--- a/src/views/task/components/task_dialog.py
+++ b/src/views/task/components/task_dialog.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 import flet as ft
 from loguru import logger
 
+from logic.application.task_application_service import TaskApplicationService
 from logic.commands.task_commands import CreateTaskCommand, UpdateTaskCommand
 from logic.factory import get_application_service_container
 from models import TaskStatus
@@ -20,7 +21,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from datetime import date
 
-    from logic.application.task_application_service import TaskApplicationService
     from models import TaskRead
 
 
@@ -104,7 +104,7 @@ class TaskDialog:
         self.on_task_updated = on_task_updated
 
         container = get_application_service_container()
-        self._task_app_service: TaskApplicationService = container.get_task_application_service()
+        self._task_app_service: TaskApplicationService = container.get_service(TaskApplicationService)
 
         # 編集モード（Noneの場合は新規作成）
         self.editing_task: TaskRead | None = None

--- a/src/views/task/components/tasks_board.py
+++ b/src/views/task/components/tasks_board.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 import flet as ft
 from loguru import logger
 
+from logic.application.task_application_service import TaskApplicationService
 from logic.commands.task_commands import UpdateTaskStatusCommand
 from logic.factory import get_application_service_container
 from models import TaskStatus
@@ -19,7 +20,6 @@ from models import TaskStatus
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from logic.application.task_application_service import TaskApplicationService
     from models import TaskRead
 
 
@@ -48,7 +48,7 @@ class TasksBoard(ft.Container):
         self.on_task_delete = on_task_delete
 
         container = get_application_service_container()
-        self._task_app_service: TaskApplicationService = container.get_task_application_service()
+        self._task_app_service: TaskApplicationService = container.get_service(TaskApplicationService)
 
         # スタイル設定
         self.bgcolor = ft.Colors.WHITE

--- a/src/views/task/view.py
+++ b/src/views/task/view.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 import flet as ft
 from loguru import logger
 
+from logic.application.task_application_service import TaskApplicationService
 from logic.commands.task_commands import DeleteTaskCommand
 from models import QuickActionCommand, TaskStatus
 from views.shared import BaseView, ErrorHandlingMixin
@@ -21,7 +22,6 @@ from views.task.components.task_dialog import TaskDialog
 from views.task.components.tasks_board import TasksBoard
 
 if TYPE_CHECKING:
-    from logic.application.task_application_service import TaskApplicationService
     from models import TaskRead
 
 
@@ -43,7 +43,7 @@ class TaskView(BaseView, ErrorHandlingMixin):
         super().__init__(page)
         logger.info("TaskView 初期化開始")
 
-        self._task_app_service: TaskApplicationService = self.container.get_task_application_service()
+        self._task_app_service: TaskApplicationService = self.container.get_service(TaskApplicationService)
 
         # ダイアログ初期化（サービスは後で注入）
         self.task_dialog = TaskDialog(

--- a/tests/logic/application/test_memo_application_service.py
+++ b/tests/logic/application/test_memo_application_service.py
@@ -31,7 +31,7 @@ class TestMemoApplicationService:
 
         # [AI GENERATED] モックの階層構造を設定
         mock_uow.service_factory = mock_service_factory
-        mock_service_factory.create_memo_service.return_value = mock_memo_service
+        mock_service_factory.get_service.return_value = mock_memo_service
 
         # [AI GENERATED] コンテキストマネージャとして機能させる
         mock_uow.__enter__ = Mock(return_value=mock_uow)
@@ -66,7 +66,7 @@ class TestMemoApplicationService:
         )
 
         # [AI GENERATED] モックの設定
-        mock_memo_service = mock_unit_of_work.service_factory.create_memo_service.return_value
+        mock_memo_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_memo_service.create_memo.return_value = created_memo
 
         # Act
@@ -121,7 +121,7 @@ class TestMemoApplicationService:
         )
 
         # [AI GENERATED] モックの設定
-        mock_memo_service = mock_unit_of_work.service_factory.create_memo_service.return_value
+        mock_memo_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_memo_service.update_memo.return_value = updated_memo
 
         # Act
@@ -156,7 +156,7 @@ class TestMemoApplicationService:
         command = DeleteMemoCommand(memo_id=memo_id)
 
         # [AI GENERATED] モックの設定
-        mock_memo_service = mock_unit_of_work.service_factory.create_memo_service.return_value
+        mock_memo_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_memo_service.delete_memo.return_value = True
 
         # Act
@@ -185,7 +185,7 @@ class TestMemoApplicationService:
         )
 
         # [AI GENERATED] モックの設定
-        mock_memo_service = mock_unit_of_work.service_factory.create_memo_service.return_value
+        mock_memo_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_memo_service.get_memo_by_id.return_value = memo
 
         # Act
@@ -206,7 +206,7 @@ class TestMemoApplicationService:
         query = GetMemoByIdQuery(memo_id=memo_id)
 
         # [AI GENERATED] モックの設定
-        mock_memo_service = mock_unit_of_work.service_factory.create_memo_service.return_value
+        mock_memo_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_memo_service.get_memo_by_id.return_value = None
 
         # Act
@@ -231,7 +231,7 @@ class TestMemoApplicationService:
         ]
 
         # [AI GENERATED] モックの設定
-        mock_memo_service = mock_unit_of_work.service_factory.create_memo_service.return_value
+        mock_memo_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_memo_service.get_all_memos.return_value = memos
 
         # Act
@@ -257,7 +257,7 @@ class TestMemoApplicationService:
         ]
 
         # [AI GENERATED] モックの設定
-        mock_memo_service = mock_unit_of_work.service_factory.create_memo_service.return_value
+        mock_memo_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_memo_service.get_memos_by_task_id.return_value = memos
 
         # Act
@@ -284,7 +284,7 @@ class TestMemoApplicationService:
         ]
 
         # [AI GENERATED] モックの設定
-        mock_memo_service = mock_unit_of_work.service_factory.create_memo_service.return_value
+        mock_memo_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_memo_service.search_memos.return_value = matching_memos
 
         # Act

--- a/tests/logic/application/test_project_application_service.py
+++ b/tests/logic/application/test_project_application_service.py
@@ -43,7 +43,7 @@ class TestProjectApplicationService:
 
         # [AI GENERATED] モックの階層構造を設定
         mock_uow.service_factory = mock_service_factory
-        mock_service_factory.create_project_service.return_value = mock_project_service
+        mock_service_factory.get_service.return_value = mock_project_service
 
         # [AI GENERATED] コンテキストマネージャとして機能させる
         mock_uow.__enter__ = Mock(return_value=mock_uow)
@@ -79,7 +79,7 @@ class TestProjectApplicationService:
     ) -> None:
         """正常系: プロジェクト作成成功"""
         # モックの設定
-        mock_project_service = mock_unit_of_work.service_factory.create_project_service.return_value
+        mock_project_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_project_service.create_project.return_value = sample_project_read
 
         # コマンド作成
@@ -115,7 +115,7 @@ class TestProjectApplicationService:
     ) -> None:
         """正常系: ID指定プロジェクト取得成功"""
         # モックの設定
-        mock_project_service = mock_unit_of_work.service_factory.create_project_service.return_value
+        mock_project_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_project_service.get_project_by_id.return_value = sample_project_read
 
         # クエリ作成
@@ -135,7 +135,7 @@ class TestProjectApplicationService:
     ) -> None:
         """異常系: ID指定プロジェクト取得でプロジェクトが見つからない"""
         # モックの設定
-        mock_project_service = mock_unit_of_work.service_factory.create_project_service.return_value
+        mock_project_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_project_service.get_project_by_id.return_value = None
 
         project_id = uuid.uuid4()
@@ -153,7 +153,7 @@ class TestProjectApplicationService:
     ) -> None:
         """正常系: 全プロジェクト取得"""
         # モックの設定
-        mock_project_service = mock_unit_of_work.service_factory.create_project_service.return_value
+        mock_project_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_project_service.get_all_projects.return_value = [sample_project_read]
 
         # クエリ作成
@@ -176,7 +176,7 @@ class TestProjectApplicationService:
     ) -> None:
         """正常系: タイトル検索"""
         # モックの設定
-        mock_project_service = mock_unit_of_work.service_factory.create_project_service.return_value
+        mock_project_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_project_service.search_projects.return_value = [sample_project_read]
 
         # クエリ作成
@@ -200,7 +200,7 @@ class TestProjectApplicationService:
     ) -> None:
         """正常系: プロジェクト更新成功"""
         # モックの設定
-        mock_project_service = mock_unit_of_work.service_factory.create_project_service.return_value
+        mock_project_service = mock_unit_of_work.service_factory.get_service.return_value
         updated_project = ProjectRead(
             id=sample_project_read.id,
             title="更新されたプロジェクト",
@@ -245,7 +245,7 @@ class TestProjectApplicationService:
     ) -> None:
         """正常系: タイトル更新なしのプロジェクト更新"""
         # モックの設定
-        mock_project_service = mock_unit_of_work.service_factory.create_project_service.return_value
+        mock_project_service = mock_unit_of_work.service_factory.get_service.return_value
         updated_project = ProjectRead(
             id=sample_project_read.id,
             title=sample_project_read.title,
@@ -276,7 +276,7 @@ class TestProjectApplicationService:
     ) -> None:
         """正常系: プロジェクト削除成功"""
         # モックの設定
-        mock_project_service = mock_unit_of_work.service_factory.create_project_service.return_value
+        mock_project_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_project_service.delete_project.return_value = True  # 削除成功
 
         project_id = uuid.uuid4()
@@ -296,7 +296,7 @@ class TestProjectApplicationService:
     ) -> None:
         """異常系: プロジェクト削除失敗"""
         # モックの設定
-        mock_project_service = mock_unit_of_work.service_factory.create_project_service.return_value
+        mock_project_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_project_service.delete_project.return_value = False  # 削除失敗
 
         project_id = uuid.uuid4()

--- a/tests/logic/application/test_tag_application_service.py
+++ b/tests/logic/application/test_tag_application_service.py
@@ -43,7 +43,7 @@ class TestTagApplicationService:
 
         # [AI GENERATED] モックの階層構造を設定
         mock_uow.service_factory = mock_service_factory
-        mock_service_factory.create_tag_service.return_value = mock_tag_service
+        mock_service_factory.get_service.return_value = mock_tag_service
 
         # [AI GENERATED] コンテキストマネージャとして機能させる
         mock_uow.__enter__ = Mock(return_value=mock_uow)
@@ -77,7 +77,7 @@ class TestTagApplicationService:
     ) -> None:
         """正常系: タグ作成成功"""
         # モックの設定
-        mock_tag_service = mock_unit_of_work.service_factory.create_tag_service.return_value
+        mock_tag_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_tag_service.create_tag.return_value = sample_tag_read
 
         # コマンド作成
@@ -111,7 +111,7 @@ class TestTagApplicationService:
     ) -> None:
         """正常系: ID指定タグ取得成功"""
         # モックの設定
-        mock_tag_service = mock_unit_of_work.service_factory.create_tag_service.return_value
+        mock_tag_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_tag_service.get_tag_by_id.return_value = sample_tag_read
 
         # クエリ作成
@@ -131,7 +131,7 @@ class TestTagApplicationService:
     ) -> None:
         """異常系: ID指定タグ取得でタグが見つからない"""
         # モックの設定
-        mock_tag_service = mock_unit_of_work.service_factory.create_tag_service.return_value
+        mock_tag_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_tag_service.get_tag_by_id.return_value = None
 
         tag_id = uuid.uuid4()
@@ -149,7 +149,7 @@ class TestTagApplicationService:
     ) -> None:
         """正常系: 全タグ取得"""
         # モックの設定
-        mock_tag_service = mock_unit_of_work.service_factory.create_tag_service.return_value
+        mock_tag_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_tag_service.get_all_tags.return_value = [sample_tag_read]
 
         # クエリ作成
@@ -172,7 +172,7 @@ class TestTagApplicationService:
     ) -> None:
         """正常系: 名前検索"""
         # モックの設定
-        mock_tag_service = mock_unit_of_work.service_factory.create_tag_service.return_value
+        mock_tag_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_tag_service.search_tags.return_value = [sample_tag_read]
 
         # クエリ作成
@@ -196,7 +196,7 @@ class TestTagApplicationService:
     ) -> None:
         """正常系: タグ更新成功"""
         # モックの設定
-        mock_tag_service = mock_unit_of_work.service_factory.create_tag_service.return_value
+        mock_tag_service = mock_unit_of_work.service_factory.get_service.return_value
         updated_tag = TagRead(
             id=sample_tag_read.id,
             name="更新されたタグ",
@@ -237,7 +237,7 @@ class TestTagApplicationService:
     ) -> None:
         """正常系: タグ削除成功"""
         # モックの設定
-        mock_tag_service = mock_unit_of_work.service_factory.create_tag_service.return_value
+        mock_tag_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_tag_service.delete_tag.return_value = True  # 削除成功
 
         tag_id = uuid.uuid4()
@@ -257,7 +257,7 @@ class TestTagApplicationService:
     ) -> None:
         """異常系: タグ削除失敗"""
         # モックの設定
-        mock_tag_service = mock_unit_of_work.service_factory.create_tag_service.return_value
+        mock_tag_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_tag_service.delete_tag.return_value = False  # 削除失敗
 
         tag_id = uuid.uuid4()

--- a/tests/logic/application/test_task_application_service.py
+++ b/tests/logic/application/test_task_application_service.py
@@ -51,7 +51,7 @@ class TestTaskApplicationService:
 
         # [AI GENERATED] モックの階層構造を設定
         mock_uow.service_factory = mock_service_factory
-        mock_service_factory.create_task_service.return_value = mock_task_service
+        mock_service_factory.get_service.return_value = mock_task_service
 
         # [AI GENERATED] コンテキストマネージャとして機能させる
         mock_uow.__enter__ = Mock(return_value=mock_uow)
@@ -88,7 +88,7 @@ class TestTaskApplicationService:
     ) -> None:
         """正常系: タスク作成成功"""
         # モックの設定
-        mock_task_service = mock_unit_of_work.service_factory.create_task_service.return_value
+        mock_task_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_task_service.create_task.return_value = sample_task_read
 
         # コマンド作成
@@ -124,7 +124,7 @@ class TestTaskApplicationService:
     ) -> None:
         """正常系: タスク更新成功"""
         # モックの設定
-        mock_task_service = mock_unit_of_work.service_factory.create_task_service.return_value
+        mock_task_service = mock_unit_of_work.service_factory.get_service.return_value
         updated_task = TaskRead(
             id=sample_task_read.id,
             title="更新されたタスク",
@@ -171,7 +171,7 @@ class TestTaskApplicationService:
     ) -> None:
         """正常系: タスク削除成功"""
         # モックの設定
-        mock_task_service = mock_unit_of_work.service_factory.create_task_service.return_value
+        mock_task_service = mock_unit_of_work.service_factory.get_service.return_value
         task_id = uuid.uuid4()
 
         # コマンド作成
@@ -192,7 +192,7 @@ class TestTaskApplicationService:
     ) -> None:
         """正常系: タスクステータス更新成功"""
         # モックの設定
-        mock_task_service = mock_unit_of_work.service_factory.create_task_service.return_value
+        mock_task_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_task_service.get_task_by_id.return_value = sample_task_read
 
         updated_task = TaskRead(
@@ -227,7 +227,7 @@ class TestTaskApplicationService:
     ) -> None:
         """異常系: タスクステータス更新時にタスクが見つからない"""
         # モックの設定
-        mock_task_service = mock_unit_of_work.service_factory.create_task_service.return_value
+        mock_task_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_task_service.get_task_by_id.return_value = None  # タスクが見つからない
 
         task_id = uuid.uuid4()
@@ -248,7 +248,7 @@ class TestTaskApplicationService:
     ) -> None:
         """正常系: ステータス別タスク取得"""
         # モックの設定
-        mock_task_service = mock_unit_of_work.service_factory.create_task_service.return_value
+        mock_task_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_task_service.get_tasks_by_status.return_value = [sample_task_read]
 
         # クエリ作成
@@ -270,7 +270,7 @@ class TestTaskApplicationService:
     ) -> None:
         """正常系: 今日のタスク件数取得"""
         # モックの設定
-        mock_task_service = mock_unit_of_work.service_factory.create_task_service.return_value
+        mock_task_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_task_service.get_today_tasks_count.return_value = EXPECTED_TODAY_TASKS_COUNT
 
         # クエリ作成
@@ -291,7 +291,7 @@ class TestTaskApplicationService:
     ) -> None:
         """正常系: ID指定タスク取得"""
         # モックの設定
-        mock_task_service = mock_unit_of_work.service_factory.create_task_service.return_value
+        mock_task_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_task_service.get_task_by_id.return_value = sample_task_read
 
         # クエリ作成
@@ -311,7 +311,7 @@ class TestTaskApplicationService:
     ) -> None:
         """正常系: ID指定タスク取得でタスクが見つからない場合"""
         # モックの設定
-        mock_task_service = mock_unit_of_work.service_factory.create_task_service.return_value
+        mock_task_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_task_service.get_task_by_id.return_value = None
 
         task_id = uuid.uuid4()
@@ -332,7 +332,7 @@ class TestTaskApplicationService:
     ) -> None:
         """正常系: 全ステータス別タスク取得"""
         # モックの設定
-        mock_task_service = mock_unit_of_work.service_factory.create_task_service.return_value
+        mock_task_service = mock_unit_of_work.service_factory.get_service.return_value
 
         # [AI GENERATED] 各ステータスでの戻り値設定
         def mock_get_tasks_by_status(status: TaskStatus) -> list[TaskRead]:

--- a/tests/logic/application/test_task_application_service_display.py
+++ b/tests/logic/application/test_task_application_service_display.py
@@ -1,7 +1,7 @@
 """TaskApplicationServiceの新機能（QuickAction、表示関連）のテストコード"""
 
 import uuid
-from datetime import UTC, date, datetime
+from datetime import date
 from unittest.mock import Mock
 
 import pytest
@@ -25,7 +25,7 @@ class TestTaskApplicationServiceDisplayFeatures:
 
         # [AI GENERATED] モックの階層構造を設定
         mock_uow.service_factory = mock_service_factory
-        mock_service_factory.create_task_service.return_value = mock_task_service
+        mock_service_factory.get_service.return_value = mock_task_service
 
         # [AI GENERATED] コンテキストマネージャとして機能させる
         mock_uow.__enter__ = Mock(return_value=mock_uow)
@@ -159,12 +159,10 @@ class TestTaskApplicationServiceDisplayFeatures:
             description=test_description,
             status=TaskStatus.NEXT_ACTION,
             due_date=test_due_date,
-            created_at=datetime.now(tz=UTC),
-            updated_at=datetime.now(tz=UTC),
         )
 
         # [AI GENERATED] モックのタスクサービスの戻り値を設定
-        mock_task_service = mock_unit_of_work.service_factory.create_task_service.return_value
+        mock_task_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_task_service.create_task.return_value = expected_task
 
         # Act
@@ -200,12 +198,10 @@ class TestTaskApplicationServiceDisplayFeatures:
             description=test_description,
             status=TaskStatus.INBOX,
             due_date=None,
-            created_at=datetime.now(tz=UTC),
-            updated_at=datetime.now(tz=UTC),
         )
 
         # [AI GENERATED] モックのタスクサービスの戻り値を設定
-        mock_task_service = mock_unit_of_work.service_factory.create_task_service.return_value
+        mock_task_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_task_service.create_task.return_value = expected_task
 
         # Act
@@ -235,12 +231,10 @@ class TestTaskApplicationServiceDisplayFeatures:
             description="",
             status=TaskStatus.SOMEDAY_MAYBE,
             due_date=None,
-            created_at=datetime.now(tz=UTC),
-            updated_at=datetime.now(tz=UTC),
         )
 
         # [AI GENERATED] モックのタスクサービスの戻り値を設定
-        mock_task_service = mock_unit_of_work.service_factory.create_task_service.return_value
+        mock_task_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_task_service.create_task.return_value = expected_task
 
         # Act

--- a/tests/logic/application/test_task_tag_application_service.py
+++ b/tests/logic/application/test_task_tag_application_service.py
@@ -46,7 +46,7 @@ class TestTaskTagApplicationService:
 
         # [AI GENERATED] モックの階層構造を設定
         mock_uow.service_factory = mock_service_factory
-        mock_service_factory.create_task_tag_service.return_value = mock_task_tag_service
+        mock_service_factory.get_service.return_value = mock_task_tag_service
 
         # [AI GENERATED] コンテキストマネージャとして機能させる
         mock_uow.__enter__ = Mock(return_value=mock_uow)
@@ -80,7 +80,7 @@ class TestTaskTagApplicationService:
     ) -> None:
         """正常系: タスクタグ作成成功"""
         # モックの設定
-        mock_task_tag_service = mock_unit_of_work.service_factory.create_task_tag_service.return_value
+        mock_task_tag_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_task_tag_service.create_task_tag.return_value = sample_task_tag_read
 
         # コマンド作成
@@ -135,7 +135,7 @@ class TestTaskTagApplicationService:
     ) -> None:
         """正常系: 全タスクタグ取得"""
         # モックの設定
-        mock_task_tag_service = mock_unit_of_work.service_factory.create_task_tag_service.return_value
+        mock_task_tag_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_task_tag_service.get_all_task_tags.return_value = [sample_task_tag_read]
 
         # クエリ作成
@@ -158,7 +158,7 @@ class TestTaskTagApplicationService:
     ) -> None:
         """正常系: タスクID指定タスクタグ取得"""
         # モックの設定
-        mock_task_tag_service = mock_unit_of_work.service_factory.create_task_tag_service.return_value
+        mock_task_tag_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_task_tag_service.get_task_tags_by_task_id.return_value = [sample_task_tag_read]
 
         # クエリ作成
@@ -181,7 +181,7 @@ class TestTaskTagApplicationService:
     ) -> None:
         """正常系: タグID指定タスクタグ取得"""
         # モックの設定
-        mock_task_tag_service = mock_unit_of_work.service_factory.create_task_tag_service.return_value
+        mock_task_tag_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_task_tag_service.get_task_tags_by_tag_id.return_value = [sample_task_tag_read]
 
         # クエリ作成
@@ -204,7 +204,7 @@ class TestTaskTagApplicationService:
     ) -> None:
         """正常系: タスクタグ存在確認（存在する場合）"""
         # モックの設定
-        mock_task_tag_service = mock_unit_of_work.service_factory.create_task_tag_service.return_value
+        mock_task_tag_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_task_tag_service.check_task_tag_exists.return_value = True
 
         # クエリ作成
@@ -230,7 +230,7 @@ class TestTaskTagApplicationService:
     ) -> None:
         """正常系: タスクタグ存在確認（存在しない場合）"""
         # モックの設定
-        mock_task_tag_service = mock_unit_of_work.service_factory.create_task_tag_service.return_value
+        mock_task_tag_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_task_tag_service.check_task_tag_exists.return_value = False
 
         # クエリ作成
@@ -256,7 +256,7 @@ class TestTaskTagApplicationService:
     ) -> None:
         """正常系: タスクとタグ指定でタスクタグ取得"""
         # モックの設定
-        mock_task_tag_service = mock_unit_of_work.service_factory.create_task_tag_service.return_value
+        mock_task_tag_service = mock_unit_of_work.service_factory.get_service.return_value
         mock_task_tag_service.get_task_tag_by_task_and_tag.return_value = sample_task_tag_read
 
         # クエリ作成
@@ -282,7 +282,7 @@ class TestTaskTagApplicationService:
     ) -> None:
         """正常系: タスクタグ削除成功"""
         # モックの設定
-        mock_task_tag_service = mock_unit_of_work.service_factory.create_task_tag_service.return_value
+        mock_task_tag_service = mock_unit_of_work.service_factory.get_service.return_value
 
         # コマンド作成
         command = DeleteTaskTagCommand(
@@ -307,7 +307,7 @@ class TestTaskTagApplicationService:
     ) -> None:
         """正常系: タスクID指定のタスクタグ削除"""
         # モックの設定
-        mock_task_tag_service = mock_unit_of_work.service_factory.create_task_tag_service.return_value
+        mock_task_tag_service = mock_unit_of_work.service_factory.get_service.return_value
 
         # コマンド作成
         command = DeleteTaskTagsByTaskCommand(task_id=sample_task_tag_read.task_id)
@@ -327,7 +327,7 @@ class TestTaskTagApplicationService:
     ) -> None:
         """正常系: タグID指定のタスクタグ削除"""
         # モックの設定
-        mock_task_tag_service = mock_unit_of_work.service_factory.create_task_tag_service.return_value
+        mock_task_tag_service = mock_unit_of_work.service_factory.get_service.return_value
 
         # コマンド作成
         command = DeleteTaskTagsByTagCommand(tag_id=sample_task_tag_read.tag_id)

--- a/tests/logic/test_factory.py
+++ b/tests/logic/test_factory.py
@@ -3,17 +3,21 @@
 RepositoryFactory と ServiceFactory の依存性注入動作をテストします。
 """
 
+from typing import Any
+
 import pytest
 from sqlmodel import Session
 
 from logic.container import ServiceContainer
 from logic.factory import (
     RepositoryFactory,
+    RepositoryFactoryError,
     ServiceFactory,
     ServiceFactoryError,
     create_service_factory,
     get_application_service_container,
 )
+from logic.repositories.base import BaseRepository
 from logic.repositories.memo import MemoRepository
 from logic.repositories.project import ProjectRepository
 from logic.repositories.tag import TagRepository
@@ -32,48 +36,49 @@ class TestRepositoryFactory:
     リポジトリファクトリの動作を検証します。
     """
 
-    def test_create_task_repository(self, test_session: Session) -> None:
-        """TaskRepository が正しく作成されることをテスト"""
+    @pytest.mark.parametrize(
+        ("repository_type", "expected_class"),
+        [
+            (TaskRepository, TaskRepository),
+            (ProjectRepository, ProjectRepository),
+            (TagRepository, TagRepository),
+            (TaskTagRepository, TaskTagRepository),
+            (MemoRepository, MemoRepository),
+        ],
+    )
+    def test_create_repository(
+        self,
+        test_session: Session,
+        repository_type: type[BaseRepository[Any, Any, Any]],
+        expected_class: type[BaseRepository[Any, Any, Any]],
+    ) -> None:
+        """create_repository が任意のリポジトリを生成することをテスト"""
         factory = RepositoryFactory(test_session)
 
-        repository = factory.create_task_repository()
+        repository = factory.create_repository(repository_type)
 
-        assert isinstance(repository, TaskRepository)
+        assert isinstance(repository, expected_class)
         assert repository.session is test_session
 
-    def test_create_project_repository(self, test_session: Session) -> None:
-        """ProjectRepository が正しく作成されることをテスト"""
+    def test_create_repository_invalid_type(self, test_session: Session) -> None:
+        """create_repository に無効なクラスを渡した場合に例外が発生することをテスト"""
         factory = RepositoryFactory(test_session)
 
-        repository = factory.create_project_repository()
+        class InvalidRepository:
+            """BaseRepository を継承しないクラス"""
 
-        assert isinstance(repository, ProjectRepository)
-        assert repository.session is test_session
+            def __init__(self, session: Session) -> None:
+                self.session = session
 
-    def test_create_tag_repository(self, test_session: Session) -> None:
-        """TagRepository が正しく作成されることをテスト"""
-        factory = RepositoryFactory(test_session)
-
-        repository = factory.create_tag_repository()
-
-        assert isinstance(repository, TagRepository)
-        assert repository.session is test_session
-
-    def test_create_task_tag_repository(self, test_session: Session) -> None:
-        """TaskTagRepository が正しく作成されることをテスト"""
-        factory = RepositoryFactory(test_session)
-
-        repository = factory.create_task_tag_repository()
-
-        assert isinstance(repository, TaskTagRepository)
-        assert repository.session is test_session
+        with pytest.raises(RepositoryFactoryError):
+            factory.create_repository(InvalidRepository)  # type: ignore[arg-type]
 
     def test_repository_factory_creates_different_instances(self, test_session: Session) -> None:
         """RepositoryFactory が呼び出しごとに新しいインスタンスを作成することをテスト"""
         factory = RepositoryFactory(test_session)
 
-        repo1 = factory.create_task_repository()
-        repo2 = factory.create_task_repository()
+        repo1 = factory.create_repository(TaskRepository)
+        repo2 = factory.create_repository(TaskRepository)
 
         # [AI GENERATED] 異なるインスタンスが作成されることを確認
         assert repo1 is not repo2
@@ -92,7 +97,7 @@ class TestServiceFactory:
         repository_factory = RepositoryFactory(test_session)
         service_factory = ServiceFactory(repository_factory)
 
-        service = service_factory.create_task_service()
+        service = service_factory.get_service(TaskService)
 
         assert isinstance(service, TaskService)
         # [AI GENERATED] 依存性が正しく注入されていることを確認
@@ -106,7 +111,7 @@ class TestServiceFactory:
         repository_factory = RepositoryFactory(test_session)
         service_factory = ServiceFactory(repository_factory)
 
-        service = service_factory.create_project_service()
+        service = service_factory.get_service(ProjectService)
 
         assert isinstance(service, ProjectService)
         # [AI GENERATED] 依存性が正しく注入されていることを確認
@@ -118,7 +123,7 @@ class TestServiceFactory:
         repository_factory = RepositoryFactory(test_session)
         service_factory = ServiceFactory(repository_factory)
 
-        service = service_factory.create_tag_service()
+        service = service_factory.get_service(TagService)
 
         assert isinstance(service, TagService)
         # [AI GENERATED] 依存性が正しく注入されていることを確認
@@ -130,7 +135,7 @@ class TestServiceFactory:
         repository_factory = RepositoryFactory(test_session)
         service_factory = ServiceFactory(repository_factory)
 
-        service = service_factory.create_task_tag_service()
+        service = service_factory.get_service(TaskTagService)
 
         assert isinstance(service, TaskTagService)
         # [AI GENERATED] 依存性が正しく注入されていることを確認
@@ -141,7 +146,7 @@ class TestServiceFactory:
         repository_factory = RepositoryFactory(test_session)
         service_factory = ServiceFactory(repository_factory)
 
-        service = service_factory.create_one_liner_service()
+        service = service_factory.get_service(OneLinerService)
 
         assert isinstance(service, OneLinerService)
         # [AI GENERATED] OneLinerServiceはリポジトリに依存しないため、リポジトリのチェックは不要
@@ -158,7 +163,7 @@ class TestServiceFactory:
         service_factory.register_service(
             CustomService,
             lambda repo_factory: CustomService(
-                memo_repo=repo_factory.create_memo_repository(),
+                memo_repo=repo_factory.create_repository(MemoRepository),
             ),
         )
 
@@ -184,8 +189,8 @@ class TestServiceFactory:
         repository_factory = RepositoryFactory(test_session)
         service_factory = ServiceFactory(repository_factory)
 
-        service1 = service_factory.create_task_service()
-        service2 = service_factory.create_task_service()
+        service1 = service_factory.get_service(TaskService)
+        service2 = service_factory.get_service(TaskService)
 
         # [AI GENERATED] 異なるインスタンスが作成されることを確認
         assert service1 is not service2
@@ -211,8 +216,8 @@ class TestFactoryFunctions:
         """create_service_factory で作成されたファクトリが動作するサービスを作成することをテスト"""
         service_factory = create_service_factory(test_session)
 
-        task_service = service_factory.create_task_service()
-        project_service = service_factory.create_project_service()
+        task_service = service_factory.get_service(TaskService)
+        project_service = service_factory.get_service(ProjectService)
 
         assert isinstance(task_service, TaskService)
         assert isinstance(project_service, ProjectService)
@@ -242,10 +247,10 @@ class TestFactoryIntegration:
         """RepositoryFactory で作成された全リポジトリが同じセッションを使用することをテスト"""
         factory = RepositoryFactory(test_session)
 
-        task_repo = factory.create_task_repository()
-        project_repo = factory.create_project_repository()
-        tag_repo = factory.create_tag_repository()
-        task_tag_repo = factory.create_task_tag_repository()
+        task_repo = factory.create_repository(TaskRepository)
+        project_repo = factory.create_repository(ProjectRepository)
+        tag_repo = factory.create_repository(TagRepository)
+        task_tag_repo = factory.create_repository(TaskTagRepository)
 
         # [AI GENERATED] 全てのリポジトリが同じセッションを使用していることを確認
         assert task_repo.session is test_session
@@ -258,8 +263,8 @@ class TestFactoryIntegration:
         repository_factory = RepositoryFactory(test_session)
         service_factory = ServiceFactory(repository_factory)
 
-        task_service = service_factory.create_task_service()
-        project_service = service_factory.create_project_service()
+        task_service = service_factory.get_service(TaskService)
+        project_service = service_factory.get_service(ProjectService)
 
         # [AI GENERATED] TaskService のリポジトリのセッションを確認
         assert task_service.task_repo.session is test_session

--- a/tests/logic/test_unit_of_work.py
+++ b/tests/logic/test_unit_of_work.py
@@ -11,6 +11,8 @@ from sqlalchemy import Engine, create_engine
 from sqlmodel import Session, SQLModel
 
 from logic.factory import RepositoryFactory, ServiceFactory
+from logic.repositories.task import TaskRepository
+from logic.services.task_service import TaskService
 from logic.unit_of_work import SqlModelUnitOfWork, UnitOfWork
 from models import Task, TaskStatus
 from tests.logic.helpers import create_test_task
@@ -168,8 +170,8 @@ class TestSqlModelUnitOfWork:
 
             with uow:
                 # [AI GENERATED] ファクトリから作成されたリポジトリが同じセッションを使用することを確認
-                task_repo = uow.repository_factory.create_task_repository()
-                task_service = uow.service_factory.create_task_service()
+                task_repo = uow.repository_factory.create_repository(TaskRepository)
+                task_service = uow.service_factory.get_service(TaskService)
 
                 assert task_repo.session is uow.session
                 assert task_service.task_repo.session is uow.session
@@ -239,7 +241,7 @@ class TestUnitOfWorkIntegration:
             uow = SqlModelUnitOfWork()
 
             with uow:
-                task_service = uow.service_factory.create_task_service()
+                task_service = uow.service_factory.get_service(TaskService)
 
                 # [AI GENERATED] タスクを作成
                 task_data = create_test_task("統合テストタスク", "Unit of Work テスト")

--- a/tests/migrations/models.py
+++ b/tests/migrations/models.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, String
 
-from settings import Base
+from .settings import Base
 
 
 class User(Base):


### PR DESCRIPTION
# 概要

factory.pyとcontainer.pyをリファクタリングし、使用箇も一緒に修正

## 変更点

- memo_application_service.py: create_memo_service()をget_service(MemoService)に変更
- project_application_service.py: create_project_service()をget_service(ProjectService)に変更
- tag_application_service.py: create_tag_service()をget_service(TagService)に変更
- task_application_service.py: create_task_service()をget_service(TaskService)に変更
- task_tag_application_service.py: create_task_tag_service()をget_service(TaskTagService)に変更
- test_memo_application_service.py: モックのサービス取得メソッドを修正
- test_project_application_service.py: モックのサービス取得メソッドを修正
- test_tag_application_service.py: モックのサービス取得メソッドを修正
- test_task_application_service.py: モックのサービス取得メソッドを修正
- test_task_tag_application_service.py: モックのサービス取得メソッドを修正
- test_task_application_service_display.py: モックのサービス取得メソッドを修正

## 関連Issue

このセクションでは、このPRが関連するIssueをリンクしてください。以下のように記述します。

- 関連Issue: #121
