### PR TITLE
feat: タグIDによるメモおよびタスクの一覧取得機能を追加

### DIFF
--- a/src/logic/application/memo_application_service.py
+++ b/src/logic/application/memo_application_service.py
@@ -165,6 +165,20 @@ class MemoApplicationService(BaseApplicationService[type[SqlModelUnitOfWork]]):
             memo_service = uow.service_factory.get_service(MemoService)
             return memo_service.get_all(with_details=with_details)
 
+    def list_by_tag(self, tag_id: uuid.UUID, *, with_details: bool = False) -> list[MemoRead]:
+        """タグIDでメモ一覧を取得する。
+
+        Args:
+            tag_id: タグID
+            with_details: 関連エンティティを含めるかどうか
+
+        Returns:
+            list[MemoRead]: タグに紐づくメモ一覧
+        """
+        with self._unit_of_work_factory() as uow:
+            memo_service = uow.get_service(MemoService)
+            return memo_service.list_by_tag(tag_id, with_details=with_details)
+
     def clarify_memo(self, memo: MemoRead) -> MemoToTaskAgentOutput:
         """自由記述メモを解析し、タスク候補とメモ状態の提案を返す。
 

--- a/src/logic/application/task_application_service.py
+++ b/src/logic/application/task_application_service.py
@@ -131,6 +131,12 @@ class TaskApplicationService(BaseApplicationService[type[SqlModelUnitOfWork]]):
             task_service = uow.service_factory.get_service(TaskService)
             return task_service.list_by_status(status, with_details=with_details)
 
+    def list_by_tag(self, tag_id: uuid.UUID, *, with_details: bool = False) -> list[TaskRead]:
+        """タグIDでタスク一覧を取得する。"""
+        with self._unit_of_work_factory() as uow:
+            task_service = uow.service_factory.get_service(TaskService)
+            return task_service.list_by_tag(tag_id, with_details=with_details)
+
     def search(
         self,
         query: str,

--- a/src/logic/services/memo_service.py
+++ b/src/logic/services/memo_service.py
@@ -8,6 +8,7 @@ import uuid
 
 from loguru import logger
 
+from errors import NotFoundError
 from logic.repositories import MemoRepository, RepositoryFactory
 from logic.services.base import MyBaseError, ServiceBase, convert_read_model, handle_service_errors
 from models import Memo, MemoCreate, MemoRead, MemoStatus, MemoUpdate
@@ -215,6 +216,25 @@ class MemoService(ServiceBase):
         memos = self.memo_repo.list_by_status(status, with_details=with_details)
         logger.debug(f"ステータス '{status}' のメモを {len(memos)} 件取得しました。")
 
+        return memos
+
+    @handle_service_errors(SERVICE_NAME, "タグ取得", MemoServiceError)
+    @convert_read_model(MemoRead, is_list=True)
+    def list_by_tag(self, tag_id: uuid.UUID, *, with_details: bool = False) -> list[Memo]:
+        """指定タグに紐づくメモ一覧を取得する。
+
+        Args:
+            tag_id: ひも付きを調べるタグID
+            with_details: メモの関連情報を含めるかどうか
+
+        Returns:
+            list[MemoRead]: 指定タグに紐づくメモ一覧
+        """
+        try:
+            memos = self.memo_repo.list_by_tag(tag_id, with_details=with_details)
+        except NotFoundError:
+            memos = []
+        logger.debug(f"タグ({tag_id})に紐づくメモを {len(memos)} 件取得しました。")
         return memos
 
     @handle_service_errors(SERVICE_NAME, "検索", MemoServiceError)

--- a/src/logic/services/task_service.py
+++ b/src/logic/services/task_service.py
@@ -201,6 +201,25 @@ class TaskService(ServiceBase):
         logger.info(f"ステータス '{status}' のタスクを取得しました: {len(tasks)} 件")
         return tasks
 
+    @handle_service_errors(SERVICE_NAME, "タグ取得", TaskServiceError)
+    @convert_read_model(TaskRead, is_list=True)
+    def list_by_tag(self, tag_id: uuid.UUID, *, with_details: bool = False) -> list[Task]:
+        """タグIDでタスクを取得する。
+
+        Args:
+            tag_id: 取得対象のタグID
+            with_details: 関連エンティティを含めるかどうか
+
+        Returns:
+            list[TaskRead]: タグにひも付くタスク一覧
+        """
+        try:
+            tasks = self.task_repo.list_by_tag(tag_id, with_details=with_details)
+        except NotFoundError:
+            tasks = []
+        logger.debug(f"タグ({tag_id})に紐づくタスクを {len(tasks)} 件取得しました。")
+        return tasks
+
     @handle_service_errors(SERVICE_NAME, "検索", TaskServiceError)
     @convert_read_model(TaskRead, is_list=True)
     def search_tasks(self, query: str, *, with_details: bool = False) -> list[Task]:

--- a/src/views/tags/presenter.py
+++ b/src/views/tags/presenter.py
@@ -64,7 +64,7 @@ class TagsPresenter:
         Returns:
             TagListItemProps
         """
-        counts = controller.get_tag_counts(tag["name"])
+        counts = controller.get_tag_counts(tag["id"])
         return TagListItemProps(
             tag_id=tag["id"],
             name=tag["name"],
@@ -106,8 +106,8 @@ class TagsPresenter:
             )
 
         # 関連アイテム取得
-        memos = controller.get_related_memos(tag["name"])
-        tasks = controller.get_related_tasks(tag["name"])
+        memos = controller.get_related_memos(tag["id"])
+        tasks = controller.get_related_tasks(tag["id"])
 
         # RelatedItem変換
         related_memos = [
@@ -130,7 +130,7 @@ class TagsPresenter:
             for t in tasks
         ]
 
-        counts = controller.get_tag_counts(tag["name"])
+        counts = controller.get_tag_counts(tag["id"])
         detail_data = TagDetailData(
             tag_id=tag["id"],
             name=tag["name"],

--- a/src/views/tags/state.py
+++ b/src/views/tags/state.py
@@ -44,7 +44,7 @@ class TagsViewState:
             object.__setattr__(self, "_filtered_tags_cache", None)
             object.__setattr__(self, "_filtered_tags_cache_search_text", None)
             object.__setattr__(self, "_filtered_tags_cache_items_id", None)
-        super().__setattr__(name, value)
+        object.__setattr__(self, name, value)
 
     @property
     def filtered_tags(self) -> list[TagDict]:

--- a/tests/logic/application/test_memo_application_service.py
+++ b/tests/logic/application/test_memo_application_service.py
@@ -169,6 +169,20 @@ class TestMemoApplicationService:
         assert len(result) == EXPECTED_PAIR_COUNT
         mock_memo_service.get_all.assert_called_once_with(with_details=False)
 
+    def test_list_by_tag(self, memo_app_service: MemoApplicationService, mock_unit_of_work: Mock) -> None:
+        """正常系: タグIDでメモ取得"""
+        mock_memo_service = mock_unit_of_work.service_factory.get_service.return_value
+        tag_id = uuid.uuid4()
+        expected = [
+            MemoRead(id=uuid.uuid4(), title="タグ付きメモ", content="memo", status=MemoStatus.INBOX),
+        ]
+        mock_memo_service.list_by_tag.return_value = expected
+
+        result = memo_app_service.list_by_tag(tag_id)
+
+        assert result == expected
+        mock_memo_service.list_by_tag.assert_called_once_with(tag_id, with_details=False)
+
     def test_clarify_memo_returns_clarify_for_empty_input(
         self,
         memo_app_service: MemoApplicationService,

--- a/tests/logic/application/test_task_application_service.py
+++ b/tests/logic/application/test_task_application_service.py
@@ -177,6 +177,22 @@ class TestTaskApplicationService:
 
         mock_task_service.list_by_status.assert_called_once_with(TaskStatus.PROGRESS, with_details=True)
 
+    def test_list_by_tag(
+        self,
+        task_application_service: TaskApplicationService,
+        mock_unit_of_work: Mock,
+        sample_task_read: TaskRead,
+    ) -> None:
+        """正常系: タグIDでタスク取得"""
+        mock_task_service = mock_unit_of_work.service_factory.get_service.return_value
+        tag_id = uuid.uuid4()
+        mock_task_service.list_by_tag.return_value = [sample_task_read]
+
+        result = task_application_service.list_by_tag(tag_id)
+
+        assert result == [sample_task_read]
+        mock_task_service.list_by_tag.assert_called_once_with(tag_id, with_details=False)
+
     # Today 件数APIは現行仕様に存在しないため対象外
 
     def test_get_by_id(

--- a/tests/views/tags/__init__.py
+++ b/tests/views/tags/__init__.py
@@ -1,0 +1,2 @@
+"""Tags view tests."""
+

--- a/tests/views/tags/test_controller.py
+++ b/tests/views/tags/test_controller.py
@@ -1,0 +1,169 @@
+"""TagsController のユニットテスト。"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import Mock, create_autospec
+
+import pytest
+
+from models import MemoRead, MemoStatus, TagRead, TaskRead, TaskStatus
+from views.tags.controller import (
+    MemoApplicationPort,
+    TagApplicationPort,
+    TagsController,
+    TaskApplicationPort,
+)
+from views.tags.state import TagsViewState
+
+
+@pytest.fixture
+def state() -> TagsViewState:
+    """空の TagsViewState を返す。"""
+
+    return TagsViewState()
+
+
+@pytest.fixture
+def tag_service() -> TagApplicationPort:
+    """TagApplicationPort のモック。"""
+
+    return create_autospec(TagApplicationPort, instance=True)
+
+
+@pytest.fixture
+def memo_service() -> MemoApplicationPort:
+    """MemoApplicationPort のモック。"""
+
+    return create_autospec(MemoApplicationPort, instance=True)
+
+
+@pytest.fixture
+def task_service() -> TaskApplicationPort:
+    """TaskApplicationPort のモック。"""
+
+    return create_autospec(TaskApplicationPort, instance=True)
+
+
+@pytest.fixture
+def controller(
+    state: TagsViewState,
+    tag_service: TagApplicationPort,
+    memo_service: MemoApplicationPort,
+    task_service: TaskApplicationPort,
+) -> TagsController:
+    """テスト対象の TagsController。"""
+
+    return TagsController(state, tag_service, memo_service, task_service)
+
+
+def _sample_tag(name: str) -> TagRead:
+    return TagRead(id=uuid.uuid4(), name=name, description=f"desc-{name}", color="#123456")
+
+
+def _sample_memo() -> MemoRead:
+    return MemoRead(id=uuid.uuid4(), title="memo", content="memo-content", status=MemoStatus.INBOX)
+
+
+def _sample_task() -> TaskRead:
+    return TaskRead(id=uuid.uuid4(), title="task", description="task-desc", status=TaskStatus.TODO)
+
+
+def test_load_initial_tags_fetches_from_service(
+    controller: TagsController,
+    state: TagsViewState,
+    tag_service: TagApplicationPort,
+) -> None:
+    """初期ロードでサービスからデータを取得する。"""
+
+    sample = _sample_tag("緊急")
+    tag_service.get_all_tags.return_value = [sample]
+
+    controller.load_initial_tags()
+
+    assert state.initial_loaded is True
+    assert len(state.items) == 1
+    assert state.items[0]["name"] == "緊急"
+    tag_service.get_all_tags.assert_called_once()
+
+
+def test_create_tag_updates_state_and_avoids_fetch(controller: TagsController, state: TagsViewState, tag_service: TagApplicationPort, memo_service: MemoApplicationPort, task_service: TaskApplicationPort) -> None:
+    """作成直後は関連データキャッシュを使用する。"""
+
+    created = _sample_tag("開発")
+    tag_service.create.return_value = created
+
+    controller.create_tag(created.name, created.color, created.description)
+
+    assert len(state.items) == 1
+    assert state.selected_id == str(created.id)
+
+    controller.get_tag_counts(str(created.id))
+    memo_service.list_by_tag.assert_not_called()
+    task_service.list_by_tag.assert_not_called()
+
+
+def test_related_items_are_cached_per_tag(
+    controller: TagsController,
+    state: TagsViewState,
+    memo_service: MemoApplicationPort,
+    task_service: TaskApplicationPort,
+) -> None:
+    """関連メモ・タスクは初回のみ取得される。"""
+
+    tag = _sample_tag("デザイン")
+    tag_id = str(tag.id)
+    state.items = [
+        {
+            "id": tag_id,
+            "name": tag.name,
+            "color": tag.color or "",
+            "description": tag.description or "",
+            "created_at": "-",
+            "updated_at": "-",
+        }
+    ]
+    memo_service.list_by_tag.return_value = [_sample_memo()]
+    task_service.list_by_tag.return_value = [_sample_task()]
+
+    first = controller.get_related_memos(tag_id)
+    second = controller.get_related_memos(tag_id)
+
+    assert len(first) == 1
+    assert second == first
+    memo_service.list_by_tag.assert_called_once()
+
+
+def test_update_tag_resets_usage_cache(
+    controller: TagsController,
+    state: TagsViewState,
+    tag_service: TagApplicationPort,
+    memo_service: MemoApplicationPort,
+) -> None:
+    """更新後はキャッシュが無効化される。"""
+
+    tag = _sample_tag("タグA")
+    tag_id = str(tag.id)
+    state.items = [
+        {
+            "id": tag_id,
+            "name": tag.name,
+            "color": tag.color or "",
+            "description": tag.description or "",
+            "created_at": "-",
+            "updated_at": "-",
+        }
+    ]
+    memo_service.list_by_tag.return_value = [_sample_memo()]
+
+    controller.get_tag_counts(tag_id)
+    assert memo_service.list_by_tag.call_count == 1
+
+    memo_service.list_by_tag.reset_mock()
+    updated = TagRead(id=tag.id, name="タグB", description="", color="#654321")
+    tag_service.update.return_value = updated
+
+    controller.update_tag(tag_id, name="タグB")
+
+    controller.get_tag_counts(tag_id)
+    memo_service.list_by_tag.assert_called_once()


### PR DESCRIPTION
# 概要

Views層にタグIDによるメモおよびタスクの一覧取得機能を追加

## 変更点

このプルリクエストでは、タグ機能に大幅な機能強化が導入され、モック実装が実際のサービス統合に置き換えられ、各タグの関連メモとタスクを動的に取得できるようになりました。これらの変更により、保守性とスケーラビリティが向上し、タグ関連の操作が実際の永続データに反映されるようになります。コントローラは、タグ、メモ、タスクに関してアプリケーションサービスと連携するようになり、プレゼンターは、すべての関連検索でタグ名ではなくタグIDを使用するように更新されました。

**アプリケーションサービスと実際のデータ取得の統合:**

* `src/views/tags/controller.py` の `TagsController` は、注入されたアプリケーションサービスポート (`TagApplicationPort`、`MemoApplicationPort`、`TaskApplicationPort`) を使用して、タグの取得、作成、更新、削除、および関連メモとタスクの取得を行うようになりました。これにより、以前のモックデータとスタブメソッドが置き換えられました。効率性向上のため、関連データはタグごとにキャッシュされるようになりました。

**アプリケーションサービスにおけるタグベースのフィルタリングのサポート:**

* `MemoApplicationService` (`src/logic/application/memo_application_service.py`) と `TaskApplicationService` (`src/logic/application/task_application_service.py`) の両方に `list_by_tag` メソッドを追加しました。これにより、タグIDでメモやタスクを取得できるようになりました。 [[1]](diffhunk://#diff-9b37bba93d4ffa76d16d5f6a681105c363691cf730d30aa359b4d062e597cb61R168-R181) [[2]](diffhunk://#diff-96b4b587fb397007dd0ae843de3fc42d58ef7bd56ac26944f7b6f9d75fb61396R134-R139)
* `MemoService` と `TaskService` に、サービスエラーを処理し、結果を読み取りモデルに変換する対応する `list_by_tag` 実装が追加されました。 [[1]](diffhunk://#diff-ce952364f312e091365fc747926c89a9c7aa3e1248429408353442fe9cb38824R221-R239) [[2]](diffhunk://#diff-007a75c15f02f84228004579862075bbcaf5fb9b481d0302c4a90fcd3dd5f7b9R204-R222)

**タグIDの使用に関するプレゼンターとビューの更新:**

* プレゼンター (`src/views/tags/presenter.py`) は、関連するメモ、タスク、カウントを取得する際に、タグ名ではなくタグIDを一貫して使用するようになりました。これにより、正確で堅牢な検索が実現します。 [[1]](diffhunk://#diff-03e405f5db2afefe3641f59d8d2eb5c28bb9d638883e80b482e2c95731c18fc8L67-R67) [[2]](diffhunk://#diff-03e405f5db2afefe3641f59d8d2eb5c28bb9d638883e80b482e2c95731c18fc8L109-R110) [[3]](diffhunk://#diff-03e405f5db2afefe3641f59d8d2eb5c28bb9d638883e80b482e2c95731c18fc8L133-R133)
*ビュー (`src/views/tags/view.py`) は、タグ、メモ、タスクの実際のアプリケーションサービスをインポートし、コントローラーへの依存性注入を準備します。

** 軽微な修正と改善:**

* `TagsViewState` の属性設定を `object.__setattr__` を使用するように修正し、プロパティキャッシュの問題を回避しました。
* 新しいサービスメソッドでのエラー処理をサポートするため、`src/logic/services/memo_service.py` で不足していた `NotFoundError` のインポートを追加しました。

## 関連Issue

このセクションでは、このPRが関連するIssueをリンクしてください。以下のように記述します。

- 関連Issue: #197 
