### PR TITLE
fix: スナックバー表示の修正

### DIFF
--- a/src/views/shared/base_view.py
+++ b/src/views/shared/base_view.py
@@ -55,36 +55,31 @@ class ErrorHandlingMixin:
                 ft.TextButton("OK", on_click=lambda _: self._close_dialog(page)),
             ],
         )
-        page.dialog = dialog  # type: ignore[attr-defined]
-        dialog.open = True
+        page.open(dialog)
         page.update()
 
     def show_error_snackbar(self, page: ft.Page, message: str = "エラーが発生しました") -> None:
         """エラースナックバーを表示する。"""
         snack_bar = ft.SnackBar(content=ft.Text(message), bgcolor=ft.Colors.ERROR)
-        page.snack_bar = snack_bar  # type: ignore[attr-defined]
-        snack_bar.open = True
+        page.open(snack_bar)
         page.update()
 
     def show_info_snackbar(self, message: str = "情報") -> None:
         """情報スナックバーを表示する。"""
         snack_bar = ft.SnackBar(content=ft.Text(message), bgcolor=ft.Colors.BLUE)
-        self.page.snack_bar = snack_bar  # type: ignore[attr-defined]
-        snack_bar.open = True
+        self.page.open(snack_bar)
         self.page.update()
 
     def show_success_snackbar(self, message: str = "成功しました") -> None:
         """成功スナックバーを表示する。"""
         snack_bar = ft.SnackBar(content=ft.Text(message), bgcolor=ft.Colors.GREEN)
-        self.page.snack_bar = snack_bar  # type: ignore[attr-defined]
-        snack_bar.open = True
+        self.page.open(snack_bar)
         self.page.update()
 
     def show_snack_bar(self, message: str, bgcolor: str | None = None) -> None:
         """汎用スナックバーを表示する。"""
         snack_bar = ft.SnackBar(content=ft.Text(message), bgcolor=bgcolor or ft.Colors.PRIMARY)
-        self.page.snack_bar = snack_bar  # type: ignore[attr-defined]
-        snack_bar.open = True
+        self.page.open(snack_bar)
         self.page.update()
 
     def handle_exception_with_dialog(


### PR DESCRIPTION
# 概要

スナックバーとモーダルが表示されない問題を修正

## 変更点

このプルリクエストは、`BaseView`クラスにおけるダイアログとスナックバーの表示方法をリファクタリングします。`page`にダイアログやスナックバーのオブジェクトを直接設定して手動で開く代わりに、よりクリーンで一貫性のあるアプローチとして`page.open()`メソッドを使用するように変更しました。

**UI表示メソッドのリファクタリング:**

* `src/views/shared/base_view.py`内の全てのダイアログおよびスナックバー表示メソッドを更新し、オブジェクトの割り当てや`open`属性の切り替えではなく`page.open()`を使用するように変更しました。これによりコードが簡素化され、UI要素を表示するためのページの組み込みメソッドを活用しています。

## 関連Issue

このセクションでは、このPRが関連するIssueをリンクしてください。以下のように記述します。

- 関連Issue: #222 
