### PR TITLE
feat: 用語管理機能のリファクタリングと改善

### DIFF
--- a/src/logic/application/apps.py
+++ b/src/logic/application/apps.py
@@ -14,6 +14,7 @@ from logic.application.one_liner_application_service import OneLinerApplicationS
 from logic.application.project_application_service import ProjectApplicationService
 from logic.application.tag_application_service import TagApplicationService
 from logic.application.task_application_service import TaskApplicationService
+from logic.application.terminology_application_service import TerminologyApplicationService
 from logic.unit_of_work import SqlModelUnitOfWork, UnitOfWork
 
 if TYPE_CHECKING:  # pragma: no cover - 型チェック専用
@@ -284,8 +285,13 @@ class ApplicationServices:
         return self.get_service(MemoToTaskApplicationService)
 
     @property
-    def settings(self) -> SettingsApplicationService:  # type: ignore[override]
+    def settings(self) -> SettingsApplicationService:
         """SettingsApplicationService を取得。"""
         from logic.application.settings_application_service import SettingsApplicationService
 
         return self.get_service(SettingsApplicationService)
+
+    @property
+    def terminology(self) -> TerminologyApplicationService:
+        """TerminologyApplicationService を取得。"""
+        return self.get_service(TerminologyApplicationService)

--- a/src/views/shared/base_view.py
+++ b/src/views/shared/base_view.py
@@ -106,7 +106,7 @@ class ErrorHandlingMixin:
         """ダイアログを閉じる。"""
         dialog_obj = getattr(page, "dialog", None)
         if dialog_obj:
-            dialog_obj.open = False
+            page.close(dialog_obj)
             page.update()
 
 

--- a/src/views/terms/components/status_tabs.py
+++ b/src/views/terms/components/status_tabs.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 import flet as ft
 
-from views.sample import SampleTermStatus
+from models import TermStatus
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -21,7 +21,7 @@ class StatusTabsProps:
     approved_count: int = 0
     draft_count: int = 0
     deprecated_count: int = 0
-    on_status_change: Callable[[SampleTermStatus], None] | None = None
+    on_status_change: Callable[[TermStatus], None] | None = None
 
 
 class TermStatusTabs(ft.Tabs):
@@ -35,7 +35,7 @@ class TermStatusTabs(ft.Tabs):
         """
         super().__init__()
         self.props = props
-        self.selected_status = SampleTermStatus.APPROVED
+        self.selected_status = TermStatus.APPROVED
 
         self._build_tabs()
         self.on_change = self._on_tab_change
@@ -54,15 +54,27 @@ class TermStatusTabs(ft.Tabs):
         tab_index = e.control.selected_index
 
         status_map = {
-            0: SampleTermStatus.APPROVED,
-            1: SampleTermStatus.DRAFT,
-            2: SampleTermStatus.DEPRECATED,
+            0: TermStatus.APPROVED,
+            1: TermStatus.DRAFT,
+            2: TermStatus.DEPRECATED,
         }
 
-        self.selected_status = status_map.get(tab_index, SampleTermStatus.APPROVED)
+        self.selected_status = status_map.get(tab_index, TermStatus.APPROVED)
 
         if self.props.on_status_change:
             self.props.on_status_change(self.selected_status)
+
+    def set_active_status(self, status: TermStatus) -> None:
+        """外部からステータスを指定してタブ選択を変更する。"""
+        status_to_index = {
+            TermStatus.APPROVED: 0,
+            TermStatus.DRAFT: 1,
+            TermStatus.DEPRECATED: 2,
+        }
+        self.selected_status = status
+        self.selected_index = status_to_index.get(status, 0)
+        with contextlib.suppress(AssertionError):
+            self.update()
 
     def set_props(self, props: StatusTabsProps) -> None:
         """新しいプロパティを設定する。

--- a/src/views/terms/components/term_card.py
+++ b/src/views/terms/components/term_card.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Final
 
 import flet as ft
 
-from views.sample import SampleTermStatus
+from models import TermStatus
 
 from .shared.constants import (
     CARD_PADDING,
@@ -68,7 +68,7 @@ class TermCardData:
     key: str
     description: str
     synonyms: tuple[str, ...]
-    status: SampleTermStatus
+    status: TermStatus
     status_text: str
     is_selected: bool = False
     on_click: Callable[[], None] | None = None
@@ -174,9 +174,9 @@ class TermCard(ft.Container):
             ステータスアイコンコントロール
         """
         icon_map = {
-            SampleTermStatus.APPROVED: ft.Icons.CHECK_CIRCLE,
-            SampleTermStatus.DRAFT: ft.Icons.HELP_OUTLINE,
-            SampleTermStatus.DEPRECATED: ft.Icons.CANCEL,
+            TermStatus.APPROVED: ft.Icons.CHECK_CIRCLE,
+            TermStatus.DRAFT: ft.Icons.HELP_OUTLINE,
+            TermStatus.DEPRECATED: ft.Icons.CANCEL,
         }
 
         return ft.Icon(

--- a/src/views/terms/components/term_detail.py
+++ b/src/views/terms/components/term_detail.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING
 
 import flet as ft
 
-from views.sample import SampleTermStatus
+from models import TermStatus
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -45,7 +45,7 @@ class TermDetailData:
     title: str
     key: str
     description: str
-    status: SampleTermStatus
+    status: TermStatus
     status_text: str
     synonyms: tuple[str, ...]
     tags: tuple[str, ...]
@@ -211,7 +211,7 @@ class TermDetailPanel:
             alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
         )
 
-    def _get_status_badge(self, status: SampleTermStatus, status_text: str) -> ft.Control:
+    def _get_status_badge(self, status: TermStatus, status_text: str) -> ft.Control:
         """ステータスバッジを取得する。
 
         Args:
@@ -222,21 +222,21 @@ class TermDetailPanel:
             バッジコントロール
         """
         status_config = {
-            SampleTermStatus.APPROVED: {
+            TermStatus.APPROVED: {
                 "bgcolor": ft.Colors.BLUE_600,
                 "color": ft.Colors.WHITE,
             },
-            SampleTermStatus.DRAFT: {
+            TermStatus.DRAFT: {
                 "bgcolor": ft.Colors.GREY_300,
                 "color": ft.Colors.ON_SURFACE,
             },
-            SampleTermStatus.DEPRECATED: {
+            TermStatus.DEPRECATED: {
                 "bgcolor": ft.Colors.GREY_300,
                 "color": ft.Colors.ON_SURFACE,
             },
         }
 
-        config = status_config.get(status, status_config[SampleTermStatus.DRAFT])
+        config = status_config.get(status, status_config[TermStatus.DRAFT])
 
         return ft.Container(
             content=ft.Text(

--- a/src/views/terms/controller.py
+++ b/src/views/terms/controller.py
@@ -20,7 +20,7 @@
 【設計の拡張ポイント】
     - SearchQueryNormalizer: 検索クエリの正規化戦略（Strategy パターン）
     - TermApplicationPort: ApplicationServiceの抽象化（依存性逆転、Protocol実装済み）
-    - 依存性注入: service=None時は暫定的にサンプルデータを使用
+    - 依存性注入: ApplicationServiceのモック注入によるテスト容易性
 
 【アーキテクチャ上の位置づけ】
     View → Controller → ApplicationService
@@ -35,27 +35,27 @@
     - 検索実行と結果反映
     - 用語選択状態の管理
     - ステータス別件数の提供
-    - CRUD操作（create/update/delete）※ApplicationService統合時に完全動作
+    - CRUD操作
 """
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Protocol, TypedDict
+from typing import Any, Callable, Protocol, TypedDict, TypeVar
+from uuid import UUID
 
 from loguru import logger
 
-from views.sample import SampleTermStatus, get_sample_terms
+from errors import NotFoundError
+from logic.application.terminology_application_service import TerminologyApplicationService
+from models import TermRead, TermStatus, TermUpdate
 
 from .query import SearchQueryNormalizer
+from .state import TermsViewState
 from .utils import sort_terms
 
-if TYPE_CHECKING:
-    from uuid import UUID
-
-    from views.sample import SampleTerm
-
-    from .state import TermsViewState
+T = TypeVar("T")
 
 
 class TermFormData(TypedDict, total=False):
@@ -69,7 +69,7 @@ class TermFormData(TypedDict, total=False):
         key: 用語の一意キー（必須）
         title: 用語のタイトル（必須）
         description: 用語の説明（任意）
-        status: 用語のステータス（TermStatus.value）
+        status: 用語のステータス（TermStatus または str）
         source_url: 参照元URL（任意）
         synonyms: 同義語のリスト（任意）
     """
@@ -77,276 +77,180 @@ class TermFormData(TypedDict, total=False):
     key: str
     title: str
     description: str | None
-    status: str
+    status: str | TermStatus
     source_url: str | None
     synonyms: list[str]
 
 
 class TermApplicationPort(Protocol):
-    """用語管理ApplicationServiceの抽象インターフェース。
+    """用語管理ApplicationServiceの抽象インターフェース。"""
 
-    依存性逆転の原則に従い、Controller層が具体的なApplicationService実装に
-    依存しないよう、Protocolで抽象化する。
-
-    将来的な実装:
-        - src/logic/application/term_application_service.py に TermApplicationService を実装
-        - UnitOfWorkパターンによるトランザクション管理
-        - Repository経由のデータアクセス
-    """
-
-    async def list_terms(self, status: SampleTermStatus | None = None) -> list[SampleTerm]:
-        """用語一覧を取得する。
-
-        Args:
-            status: フィルタするステータス。Noneの場合は全件取得。
-
-        Returns:
-            用語のリスト
-        """
+    def list_terms(self, status: TermStatus | None = None) -> list[TermRead]:  # pragma: no cover - interface
+        """用語一覧を取得する。"""
         ...
 
-    async def search_terms(self, query: str) -> list[SampleTerm]:
-        """用語を検索する。
-
-        Args:
-            query: 検索クエリ
-
-        Returns:
-            検索にマッチした用語のリスト
-        """
+    def search_terms(self, query: str) -> list[TermRead]:  # pragma: no cover - interface
+        """用語を検索する。"""
         ...
 
-    async def create_term(self, form_data: TermFormData) -> SampleTerm:
-        """用語を作成する。
-
-        Args:
-            form_data: 用語作成フォームデータ
-
-        Returns:
-            作成された用語
-
-        Raises:
-            ValueError: バリデーションエラー
-        """
+    def create_term(self, form_data: TermFormData) -> TermRead:  # pragma: no cover - interface
+        """用語を作成する。"""
         ...
 
-    async def update_term(self, term_id: UUID, form_data: TermFormData) -> SampleTerm:
-        """用語を更新する。
-
-        Args:
-            term_id: 更新対象の用語ID
-            form_data: 用語更新フォームデータ
-
-        Returns:
-            更新された用語
-
-        Raises:
-            ValueError: バリデーションエラー
-        """
+    def update_term(self, term_id: UUID, form_data: TermFormData) -> TermRead:  # pragma: no cover - interface
+        """用語を更新する。"""
         ...
 
-    async def delete_term(self, term_id: UUID) -> bool:
-        """用語を削除する。
-
-        Args:
-            term_id: 削除対象の用語ID
-
-        Returns:
-            削除成功時True
-
-        Raises:
-            ValueError: 用語が見つからない場合
-        """
+    def delete_term(self, term_id: UUID) -> bool:  # pragma: no cover - interface
+        """用語を削除する。"""
         ...
 
 
 @dataclass(slots=True)
 class TermsController:
-    """TermsView 用の状態操作とサービス呼び出しを集約する。
-
-    依存性注入により、ApplicationServiceをモック可能な設計とする。
-    service=Noneの場合は暫定的にサンプルデータを使用する。
-    """
+    """TermsView 用の状態操作とサービス呼び出しを集約する。"""
 
     state: TermsViewState
-    service: TermApplicationPort | None = None
+    service: TermApplicationPort
     query_normalizer: SearchQueryNormalizer = field(default_factory=SearchQueryNormalizer)
 
     async def load_initial_terms(self) -> None:
         """初期表示に使用する用語一覧を読み込む。"""
         logger.info("Loading initial terms")
-
-        if self.service:
-            terms = await self.service.list_terms()
-        else:
-            # 暫定: サンプルデータ使用
-            terms = get_sample_terms()
-
+        terms = await self._call_service(self.service.list_terms)
         ordered = sort_terms(terms)
         self.state.set_all_terms(ordered)
         self.state.set_search_result("", None)
-        logger.info(f"Loaded {len(terms)} terms")
+        logger.info("Loaded {} terms", len(terms))
 
-    def update_tab(self, tab: SampleTermStatus) -> None:
-        """タブ変更時に状態を更新する。
-
-        Args:
-            tab: 選択されたタブのステータス
-        """
-        logger.debug(f"Switching to tab: {tab}")
+    def update_tab(self, tab: TermStatus) -> None:
+        """タブ変更時に状態を更新する。"""
+        logger.debug("Switching to tab: {}", tab)
         self.state.set_current_tab(tab)
 
     async def update_search(self, query: str) -> None:
-        """検索クエリを更新し結果を反映する。
-
-        Args:
-            query: 検索クエリ文字列
-        """
+        """検索クエリを更新し結果を反映する。"""
         normalized = self.query_normalizer.normalize(query)
-        logger.debug(f"Search query: {normalized.normalized}")
+        logger.debug("Search query: {}", normalized.normalized)
 
         if not normalized.normalized:
-            # 空クエリの場合は検索を無効化
             self.state.set_search_result("", None)
-        else:
-            # 検索を実行
-            results = await self._perform_search(normalized.normalized)
-            self.state.set_search_result(normalized.normalized, results)
+            return
+
+        results = await self._perform_search(normalized.normalized)
+        self.state.set_search_result(normalized.normalized, results)
 
     def select_term(self, term_id: UUID | None) -> None:
-        """用語を選択する。
-
-        Args:
-            term_id: 選択する用語のID。Noneの場合は選択解除。
-        """
-        logger.debug(f"Selecting term: {term_id}")
+        """用語を選択する。"""
+        logger.debug("Selecting term: {}", term_id)
         self.state.set_selected_term(term_id)
 
-    def get_counts(self) -> dict[SampleTermStatus, int]:
-        """ステータス別の用語件数を取得する。
-
-        Returns:
-            ステータスごとの件数
-        """
+    def get_counts(self) -> dict[TermStatus, int]:
+        """ステータス別の用語件数を取得する。"""
         return self.state.counts_by_status
 
-    async def _perform_search(self, query: str) -> list[SampleTerm]:
-        """検索を実行する。
-
-        Args:
-            query: 正規化済みの検索クエリ
-
-        Returns:
-            検索にマッチした用語のリスト
-        """
-        if self.service:
-            results = await self.service.search_terms(query)
-        else:
-            # 暫定: ローカル検索
-            results = [term for term in self.state.all_terms if self._matches_query(term, query)]
-
-        return sort_terms(results)
-
-    def _matches_query(self, term: SampleTerm, query: str) -> bool:
-        """用語が検索クエリにマッチするかを判定する。
-
-        Args:
-            term: 判定対象の用語
-            query: 検索クエリ（小文字）
-
-        Returns:
-            マッチする場合はTrue
-        """
-        # タイトル、キー、説明、同義語で検索
-        return (
-            query in term.title.lower()
-            or query in term.key.lower()
-            or (term.description and query in term.description.lower())
-            or any(query in synonym.lower() for synonym in term.synonyms)
-        )
-
-    async def create_term(self, form_data: TermFormData) -> SampleTerm:
-        """新しい用語を作成する。
-
-        Args:
-            form_data: 用語作成フォームデータ
-
-        Returns:
-            作成された用語
-
-        Raises:
-            ValueError: バリデーションエラー
-            RuntimeError: ApplicationServiceが未設定の場合
-        """
-        if not self.service:
-            msg = "ApplicationService が設定されていません"
-            raise RuntimeError(msg)
-
-        logger.info(f"Creating term: {form_data.get('key')}")
-        created_term = await self.service.create_term(form_data)
-
-        # State を更新
+    async def create_term(self, form_data: TermFormData) -> TermRead:
+        """新しい用語を作成し、状態を更新する。"""
+        logger.info("Creating term: {}", form_data.get("key"))
+        created_term = await self._call_service(self.service.create_term, form_data)
         self.state.upsert_term(created_term)
-
-        logger.info(f"Created term: {created_term.key} (ID: {created_term.id})")
+        logger.info("Created term: {} (ID: {})", created_term.key, created_term.id)
         return created_term
 
-    async def update_term(self, term_id: UUID, form_data: TermFormData) -> SampleTerm:
-        """既存の用語を更新する。
-
-        Args:
-            term_id: 更新対象の用語ID
-            form_data: 用語更新フォームデータ
-
-        Returns:
-            更新された用語
-
-        Raises:
-            ValueError: バリデーションエラー
-            RuntimeError: ApplicationServiceが未設定の場合
-        """
-        if not self.service:
-            msg = "ApplicationService が設定されていません"
-            raise RuntimeError(msg)
-
-        logger.info(f"Updating term: {term_id}")
-        updated_term = await self.service.update_term(term_id, form_data)
-
-        # State を更新
+    async def update_term(self, term_id: UUID, form_data: TermFormData) -> TermRead:
+        """既存の用語を更新する。"""
+        logger.info("Updating term: {}", term_id)
+        updated_term = await self._call_service(self.service.update_term, term_id, form_data)
         self.state.upsert_term(updated_term)
-
-        logger.info(f"Updated term: {updated_term.key} (ID: {updated_term.id})")
+        logger.info("Updated term: {} (ID: {})", updated_term.key, updated_term.id)
         return updated_term
 
     async def delete_term(self, term_id: UUID) -> bool:
-        """用語を削除する。
-
-        Args:
-            term_id: 削除対象の用語ID
-
-        Returns:
-            削除成功時True
-
-        Raises:
-            ValueError: 用語が見つからない場合
-            RuntimeError: ApplicationServiceが未設定の場合
-        """
-        if not self.service:
-            msg = "ApplicationService が設定されていません"
-            raise RuntimeError(msg)
-
-        logger.info(f"Deleting term: {term_id}")
-        success = await self.service.delete_term(term_id)
+        """用語を削除する。"""
+        logger.info("Deleting term: {}", term_id)
+        success = await self._call_service(self.service.delete_term, term_id)
 
         if success:
-            # State から削除
             self.state.all_terms = [t for t in self.state.all_terms if t.id != term_id]
+            if self.state.search_results is not None:
+                self.state.search_results = [t for t in self.state.search_results if t.id != term_id]
             self.state.rebuild_index()
-
-            # 選択状態をクリア
             if self.state.selected_term_id == term_id:
                 self.state.selected_term_id = None
-
-            logger.info(f"Deleted term: {term_id}")
+            logger.info("Deleted term: {}", term_id)
 
         return success
+
+    async def _perform_search(self, query: str) -> list[TermRead]:
+        """検索を実行する。"""
+        results = await self._call_service(self.service.search_terms, query)
+        return sort_terms(results)
+
+    async def _call_service(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+        """ブロッキングなサービス呼び出しをスレッドで実行する。"""
+        return await asyncio.to_thread(func, *args, **kwargs)
+
+
+class TerminologyApplicationPortAdapter(TermApplicationPort):
+    """TerminologyApplicationService を TermApplicationPort に適合させる。"""
+
+    def __init__(self, service: TerminologyApplicationService) -> None:
+        self._service = service
+
+    def list_terms(self, status: TermStatus | None = None) -> list[TermRead]:
+        try:
+            if status:
+                return self._service.search(query=None, status=status)
+            return self._service.get_all()
+        except NotFoundError:
+            logger.info("TerminologyApplicationService returned no records.")
+            return []
+
+    def search_terms(self, query: str) -> list[TermRead]:
+        return self._service.search(query=query)
+
+    def create_term(self, form_data: TermFormData) -> TermRead:
+        status = _parse_status(form_data.get("status"), default=TermStatus.DRAFT)
+        description = _clean_text(form_data.get("description"))
+        source_url = _clean_text(form_data.get("source_url"))
+        return self._service.create(
+            key=_clean_text(form_data.get("key"), default=""),
+            title=_clean_text(form_data.get("title"), default=""),
+            description=description,
+            status=status or TermStatus.DRAFT,
+            source_url=source_url,
+        )
+
+    def update_term(self, term_id: UUID, form_data: TermFormData) -> TermRead:
+        update_model = TermUpdate(
+            key=_clean_text(form_data.get("key")),
+            title=_clean_text(form_data.get("title")),
+            description=_clean_text(form_data.get("description")),
+            status=_parse_status(form_data.get("status")),
+            source_url=_clean_text(form_data.get("source_url")),
+        )
+        return self._service.update(term_id, update_model)
+
+    def delete_term(self, term_id: UUID) -> bool:
+        return self._service.delete(term_id)
+
+
+def _parse_status(value: str | TermStatus | None, *, default: TermStatus | None = None) -> TermStatus | None:
+    """フォームから渡されたステータス値を TermStatus に変換する。"""
+    if isinstance(value, TermStatus):
+        return value
+    if isinstance(value, str) and value:
+        try:
+            return TermStatus(value)
+        except ValueError:
+            logger.warning("Unknown term status value: {}", value)
+            return default
+    return default
+
+
+def _clean_text(value: str | None, *, default: str | None = None) -> str | None:
+    """文字列フィールドをトリムし、空文字の場合はデフォルト値を返す。"""
+    if value is None:
+        return default
+    stripped = value.strip()
+    return stripped if stripped else default

--- a/src/views/terms/utils.py
+++ b/src/views/terms/utils.py
@@ -13,15 +13,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from datetime import datetime
 
-if TYPE_CHECKING:
-    from datetime import datetime
-
-    from views.sample import SampleTerm
+from models import TermRead
 
 
-def format_date(dt: datetime) -> str:
+def format_date(dt: datetime | None) -> str:
     """日時を日本語フォーマットに変換する。
 
     Args:
@@ -30,10 +27,12 @@ def format_date(dt: datetime) -> str:
     Returns:
         "YYYY年MM月DD日" 形式の文字列
     """
+    if not dt:
+        return "-"
     return dt.strftime("%Y年%m月%d日")
 
 
-def format_datetime(dt: datetime) -> str:
+def format_datetime(dt: datetime | None) -> str:
     """日時を詳細な日本語フォーマットに変換する。
 
     Args:
@@ -42,10 +41,12 @@ def format_datetime(dt: datetime) -> str:
     Returns:
         "YYYY年MM月DD日 HH:MM" 形式の文字列
     """
+    if not dt:
+        return "-"
     return dt.strftime("%Y年%m月%d日 %H:%M")
 
 
-def get_term_sort_key(term: SampleTerm) -> tuple[float, str]:
+def get_term_sort_key(term: TermRead) -> tuple[float, str]:
     """用語のソートキーを生成する。
 
     更新日時の降順、同一の場合はタイトルの昇順。
@@ -56,10 +57,11 @@ def get_term_sort_key(term: SampleTerm) -> tuple[float, str]:
     Returns:
         ソートキーのタプル（更新日時の逆順、タイトル）
     """
-    return (-term.updated_at.timestamp(), term.title.lower())
+    updated_at = term.updated_at or datetime.fromtimestamp(0)
+    return (-updated_at.timestamp(), (term.title or "").lower())
 
 
-def sort_terms(terms: list[SampleTerm]) -> list[SampleTerm]:
+def sort_terms(terms: list[TermRead]) -> list[TermRead]:
     """用語リストをソートする。
 
     Args:

--- a/tests/views/terms/__init__.py
+++ b/tests/views/terms/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for views.terms module."""

--- a/tests/views/terms/test_adapter.py
+++ b/tests/views/terms/test_adapter.py
@@ -1,0 +1,129 @@
+"""Tests for TerminologyApplicationPortAdapter."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from models import TermRead, TermStatus
+from views.terms.controller import TermFormData, TerminologyApplicationPortAdapter
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:  # pragma: no cover - fallback for minimal environments
+    from mock import MagicMock  # type: ignore[no-redef]
+
+
+def _make_term(key: str, title: str) -> TermRead:
+    return TermRead(
+        id=uuid4(),
+        key=key,
+        title=title,
+        description=None,
+        status=TermStatus.APPROVED,
+        source_url=None,
+    )
+
+
+def test_adapter_list_terms_delegates_to_service() -> None:
+    """list_terms should call appropriate service method."""
+    service = MagicMock()
+    adapter = TerminologyApplicationPortAdapter(service)
+
+    service.get_all.return_value = [_make_term("a", "A")]
+    assert adapter.list_terms() == service.get_all.return_value
+    service.get_all.assert_called_once_with()
+
+    service.reset_mock()
+    filtered = [_make_term("b", "B")]
+    service.search.return_value = filtered
+    assert adapter.list_terms(status=TermStatus.APPROVED) == filtered
+    service.search.assert_called_once_with(query=None, status=TermStatus.APPROVED)
+
+
+def test_adapter_list_terms_handles_not_found() -> None:
+    """list_terms should gracefully handle NotFoundError and return empty list."""
+    service = MagicMock()
+    adapter = TerminologyApplicationPortAdapter(service)
+    from errors import NotFoundError
+
+    service.get_all.side_effect = NotFoundError("no terms")
+
+    assert adapter.list_terms() == []
+    service.get_all.assert_called_once_with()
+
+
+def test_adapter_search_terms_uses_service_search() -> None:
+    """search_terms should delegate to service.search."""
+    service = MagicMock()
+    adapter = TerminologyApplicationPortAdapter(service)
+    expected = [_make_term("k", "Kappa")]
+    service.search.return_value = expected
+
+    assert adapter.search_terms("ka") == expected
+    service.search.assert_called_once_with(query="ka")
+
+
+def test_adapter_create_term_normalizes_payload() -> None:
+    """create_term should strip text and coerce statuses."""
+    service = MagicMock()
+    adapter = TerminologyApplicationPortAdapter(service)
+    created = _make_term("key", "Title")
+    service.create.return_value = created
+
+    form_data: TermFormData = {
+        "key": " key ",
+        "title": " Title ",
+        "description": " desc ",
+        "status": "approved",
+        "source_url": " https://example.com ",
+        "synonyms": [],
+    }
+    result = adapter.create_term(form_data)
+
+    assert result is created
+    service.create.assert_called_once_with(
+        key="key",
+        title="Title",
+        description="desc",
+        status=TermStatus.APPROVED,
+        source_url="https://example.com",
+    )
+
+
+def test_adapter_update_term_builds_update_model() -> None:
+    """update_term should pass TermUpdate with normalized values."""
+    service = MagicMock()
+    adapter = TerminologyApplicationPortAdapter(service)
+    updated = _make_term("key", "Title")
+    service.update.return_value = updated
+    term_id = uuid4()
+
+    form_data: TermFormData = {
+        "key": " new_key ",
+        "title": " new title ",
+        "description": None,
+        "status": TermStatus.DEPRECATED,
+        "source_url": " ",
+        "synonyms": [],
+    }
+    result = adapter.update_term(term_id, form_data)
+
+    assert result is updated
+    service.update.assert_called_once()
+    _, update_model = service.update.call_args[0]
+    assert update_model.key == "new_key"
+    assert update_model.title == "new title"
+    assert update_model.description is None
+    assert update_model.status == TermStatus.DEPRECATED
+    assert update_model.source_url is None
+
+
+def test_adapter_delete_term_returns_service_result() -> None:
+    """delete_term should return service.delete value."""
+    service = MagicMock()
+    adapter = TerminologyApplicationPortAdapter(service)
+    service.delete.return_value = True
+    term_id = uuid4()
+
+    assert adapter.delete_term(term_id) is True
+    service.delete.assert_called_once_with(term_id)

--- a/tests/views/terms/test_controller.py
+++ b/tests/views/terms/test_controller.py
@@ -1,0 +1,148 @@
+"""Tests for TermsController."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+from uuid import UUID, uuid4
+
+from models import TermRead, TermStatus
+from views.terms.controller import TermApplicationPort, TermFormData, TermsController
+from views.terms.state import TermsViewState
+
+
+def _make_term(
+    key: str,
+    title: str,
+    *,
+    status: TermStatus = TermStatus.APPROVED,
+    updated_at: datetime | None = None,
+) -> TermRead:
+    """Helper to build TermRead objects for tests."""
+    return TermRead(
+        id=uuid4(),
+        key=key,
+        title=title,
+        description="description",
+        status=status,
+        source_url=None,
+        created_at=datetime.now(),
+        updated_at=updated_at or datetime.now(),
+    )
+
+
+class FakeTermService(TermApplicationPort):
+    """In-memory TermApplicationPort implementation for controller tests."""
+
+    def __init__(self) -> None:
+        now = datetime.now()
+        self._terms: list[TermRead] = [
+            _make_term("alpha", "Alpha", updated_at=now - timedelta(days=1)),
+            _make_term("beta", "Beta", status=TermStatus.DRAFT, updated_at=now),
+        ]
+
+    def list_terms(self, status: TermStatus | None = None) -> list[TermRead]:
+        if status:
+            return [term for term in self._terms if term.status == status]
+        return list(self._terms)
+
+    def search_terms(self, query: str) -> list[TermRead]:
+        keyword = query.lower()
+        return [term for term in self._terms if keyword in term.title.lower()]
+
+    def create_term(self, form_data: TermFormData) -> TermRead:
+        status_value = form_data.get("status", TermStatus.DRAFT)
+        status = status_value if isinstance(status_value, TermStatus) else TermStatus(status_value)
+        term = _make_term(
+            form_data.get("key", "new"),
+            form_data.get("title", "New Term"),
+            status=status,
+        )
+        self._terms.append(term)
+        return term
+
+    def update_term(self, term_id: UUID, form_data: TermFormData) -> TermRead:
+        for term in self._terms:
+            if term.id == term_id:
+                term.title = form_data.get("title", term.title) or term.title
+                status_value = form_data.get("status")
+                if status_value:
+                    term.status = status_value if isinstance(status_value, TermStatus) else TermStatus(status_value)
+                term.updated_at = datetime.now()
+                return term
+        msg = f"Term not found: {term_id}"
+        raise ValueError(msg)
+
+    def delete_term(self, term_id: UUID) -> bool:
+        for index, term in enumerate(self._terms):
+            if term.id == term_id:
+                self._terms.pop(index)
+                return True
+        return False
+
+
+def _run(coro):
+    """Utility to execute controller coroutines."""
+    return asyncio.run(coro)
+
+
+def test_load_initial_terms_populates_state() -> None:
+    """Controller should populate state from service."""
+    state = TermsViewState()
+    controller = TermsController(state=state, service=FakeTermService())
+
+    _run(controller.load_initial_terms())
+
+    assert len(state.all_terms) == 2
+    assert state.search_results is None
+    assert state.all_terms[0].updated_at >= state.all_terms[1].updated_at
+
+
+def test_update_search_filters_terms() -> None:
+    """Controller should update search results based on query."""
+    state = TermsViewState()
+    controller = TermsController(state=state, service=FakeTermService())
+    _run(controller.load_initial_terms())
+
+    _run(controller.update_search("alp"))
+
+    assert state.search_results is not None
+    assert len(state.search_results) == 1
+    assert state.search_results[0].key == "alpha"
+
+
+def test_create_term_updates_state() -> None:
+    """Creating a term should add it to state."""
+    state = TermsViewState()
+    controller = TermsController(state=state, service=FakeTermService())
+    _run(controller.load_initial_terms())
+
+    form_data: TermFormData = {
+        "key": "gamma",
+        "title": "Gamma",
+        "description": "desc",
+        "status": TermStatus.APPROVED,
+        "source_url": None,
+        "synonyms": [],
+    }
+    created = _run(controller.create_term(form_data))
+
+    assert any(term.id == created.id for term in state.all_terms)
+    assert created.title == "Gamma"
+
+
+def test_delete_term_updates_state_and_results() -> None:
+    """Deleting a term should remove it from both all_terms and search_results."""
+    state = TermsViewState()
+    controller = TermsController(state=state, service=FakeTermService())
+    _run(controller.load_initial_terms())
+    target_id = state.all_terms[0].id
+
+    _run(controller.update_search(state.all_terms[0].title))
+    assert state.search_results is not None
+
+    _run(controller.delete_term(target_id))
+
+    assert all(term.id != target_id for term in state.all_terms)
+    assert state.search_results is not None
+    assert all(term.id != target_id for term in state.search_results)


### PR DESCRIPTION
# 概要

term viewとlogic層を接続

## 変更点

このプルリクエストは、用語管理機能をリファクタリングし、新しい `TerminologyApplicationService` ドメインロジックと完全に統合することで、以前のサンプル/モック実装を置き換えます。コードベース全体で `TermStatus` モデルの使用を標準化し、サービス呼び出し用のスレッドセーフなアダプタを導入することで、テスト性と保守性を向上させます。さらに、UI コンポーネントとコントローラロジックを更新し、実際のデータモデルとサービスで動作するようにしました。

**ドメインサービスの統合と抽象化**

* アプリケーション層に `TerminologyApplicationService` を導入し、依存性注入用の `src/logic/application/apps.py` に対応するプロパティを追加しました。 [[1]](diffhunk://#diff-f957565e387805fc36ab583bdcefea2d0e32abb21d673a0cb6a24f72427e58e7R17) [[2]](diffhunk://#diff-f957565e387805fc36ab583bdcefea2d0e32abb21d673a0cb6a24f72427e58e7L287-R297)
* `TermsController` をリファクタリングし、実際の `TermApplicationPort` インターフェースを使用するようにしました。これにより、サンプル/モックデータのロジックがすべて削除され、`asyncio.to_thread` を介して非同期かつスレッドセーフなサービス呼び出しが実装されました。 [[1]](diffhunk://#diff-8a30cbb4fb0d2e4ebc87f40a7c4ed7d81b940fabb65be1b51768c1c00d796361L38-R58) [[2]](diffhunk://#diff-8a30cbb4fb0d2e4ebc87f40a7c4ed7d81b940fabb65be1b51768c1c00d796361L72-R256)
* `TerminologyApplicationService` とコントローラーインターフェースをブリッジする `TerminologyApplicationPortAdapter` を追加しました。これには、堅牢なステータス解析およびテキストクリーニングユーティリティが含まれます。

**モデルと型の標準化**

* UI コンポーネントとコントローラーロジックにおける `SampleTermStatus` およびサンプル用語モデルの使用をすべて、実際の `TermStatus` および `TermRead` モデルに置き換え、一貫性を確保しました。 [[1]](diffhunk://#diff-4be42a64267a4981bfedb6c21961da6243469f8c6830a9ee8c82ef4fc4381d01L11-R11) [[2]](diffhunk://#diff-4be42a64267a4981bfedb6c21961da6243469f8c6830a9ee8c82ef4fc4381d01L24-R24) [[3]](diffhunk://#diff-4be42a64267a4981bfedb6c21961da6243469f8c6830a9ee8c82ef4fc4381d01L38-R38) [[4]](diffhunk://#diff-4be42a64267a4981bfedb6c21961da6243469f8c6830a9ee8c82ef4fc4381d01L57-R78) [[5]](diffhunk://#diff-8d11fd08274cfd483b9f6593693b3b79dafc2503ca9c6542b31f8c835b6d9827L23-R23) [[6]](diffhunk://#diff-8d11fd08274cfd483b9f6593693b3b79dafc2503ca9c6542b31f8c835b6d9827L71-R71) [[7]](diffhunk://#diff-8d11fd08274cfd483b9f6593693b3b79dafc2503ca9c6542b31f8c835b6d9827L177-R179) [[8]](diffhunk://#diff-558fe85cb7bc94487eb5cff2f7c0f33f979bbcb3826673d54a18f95dc748fb06L24-R24) [[9]](diffhunk://#diff-558fe85cb7bc94487eb5cff2f7c0f33f979bbcb3826673d54a18f95dc748fb06L48-R48) [[10]](diffhunk://#diff-558fe85cb7bc94487eb5cff2f7c0f33f979bbcb3826673d54a18f95dc748fb06L214-R214) [[11]](diffhunk://#diff-558fe85cb7bc94487eb5cff2f7c0f33f979bbcb3826673d54a18f95dc748fb06L225-R239) [[12]](diffhunk://#diff-8a30cbb4fb0d2e4ebc87f40a7c4ed7d81b940fabb65be1b51768c1c00d796361L72-R256)

**UIコンポーネントの更新**

* `StatusTabs`、`TermCard`、`TermDetail`コンポーネントを更新し、新しいステータスモデルを使用するようにしました。また、`StatusTabs`に外部タブ選択機能を追加しました。 [[1]](diffhunk://#diff-4be42a64267a4981bfedb6c21961da6243469f8c6830a9ee8c82ef4fc4381d01L38-R38) [[2]](diffhunk://#diff-4be42a64267a4981bfedb6c21961da6243469f8c6830a9ee8c82ef4fc4381d01L57-R78)
* 共有ビューのダイアログを閉じるロジックを改善し、UIの一貫性を向上させました。

**ドキュメントとコードコメント**

* 新しいアーキテクチャを反映するようにコントローラーのドキュメントを改訂し、サンプルデータとモックの使用に関する古いコメントを削除しました。 [[1]](diffhunk://#diff-8a30cbb4fb0d2e4ebc87f40a7c4ed7d81b940fabb65be1b51768c1c00d796361L23-R23) [[2]](diffhunk://#diff-8a30cbb4fb0d2e4ebc87f40a7c4ed7d81b940fabb65be1b51768c1c00d796361L38-R58)

これらの変更により、用語機能がモック/サンプルベースのアーキテクチャから本番環境対応のドメイン駆動設計へと移行され、信頼性と保守性が向上します。
## 関連Issue

このセクションでは、このPRが関連するIssueをリンクしてください。以下のように記述します。

- 関連Issue: #197 
