### PR TITLE
feat: 週次レビュー用のタスクとメモを追加し、作成日オフセットを適用する処理を実装

### DIFF
--- a/scripts/seed_sample_data.py
+++ b/scripts/seed_sample_data.py
@@ -482,11 +482,10 @@ def _calculate_completed_at(offset_days: int | None) -> datetime | None:
     return datetime.now() - timedelta(days=offset_days)
 
 
-def _apply_task_created_offsets(apps: ApplicationServices, offset_mapping: dict["uuid.UUID", int]) -> None:
+def _apply_task_created_offsets(offset_mapping: dict[uuid.UUID, int]) -> None:
     """Task.created_at を過去日にずらして停滞タスクを用意する。
 
     Args:
-        apps: ApplicationServices ファサード。
         offset_mapping: タスクIDと過去に遡る日数の対応。
     """
     valid_offsets = {task_id: days for task_id, days in offset_mapping.items() if days > 0}
@@ -494,18 +493,24 @@ def _apply_task_created_offsets(apps: ApplicationServices, offset_mapping: dict[
         return
 
     updated_count = 0
-    for task_id, days in valid_offsets.items():
-        task = apps.task.get_task(task_id)
-        if task is None:
-            logger.warning(f"created_at を更新できませんでした: task_id={task_id}")
-            continue
-        target_created_at = datetime.now() - timedelta(days=days)
-        update_data = TaskUpdate(
-            created_at=target_created_at,
-            updated_at=target_created_at if task.updated_at is None or task.updated_at < target_created_at else task.updated_at,
-        )
-        apps.task.update(task_id, update_data)
-        updated_count += 1
+    # NOTE: サンプルデータ投入用のユーティリティでのみ UoW を直接扱う。
+    # 通常のアプリケーションコードでは ApplicationServices 経由で更新すること。
+    with SqlModelUnitOfWork() as uow:
+        for task_id, days in valid_offsets.items():
+            task = uow.session.get(Task, task_id)
+            if task is None:
+                logger.warning(f"created_at を更新できませんでした: task_id={task_id}")
+                continue
+
+            target_created_at = datetime.now() - timedelta(days=days)
+            task.created_at = target_created_at
+            if task.updated_at is None or task.updated_at < target_created_at:
+                task.updated_at = target_created_at
+
+            uow.session.add(task)
+            updated_count += 1
+
+        uow.session.commit()
     logger.info("停滞タスク用の created_at を {} 件更新しました。", updated_count)
 
 


### PR DESCRIPTION
# 概要

タイトル通り

## 変更点

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- 新しいメモ「週次レビュー: サポート依頼の整理」と「フォーカスブロック候補のメモ」を追加
- タスク「週次レビューガイドのアップデート」を追加
- タスクの作成日オフセットを適用するための関数を実装
- 既存のタスク作成処理に作成日オフセットの適用を追加

## 関連Issue

このセクションでは、このPRが関連するIssueをリンクしてください。以下のように記述します。

- 関連Issue: #274 
